### PR TITLE
feat: add multi-platform distribution support

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,107 @@
+name: Publish npm packages
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish-platforms:
+    name: Publish ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: darwin-arm64
+            artifact: cc-audit-${{ github.ref_name }}-aarch64-apple-darwin.tar.gz
+            binary: cc-audit
+          - platform: darwin-x64
+            artifact: cc-audit-${{ github.ref_name }}-x86_64-apple-darwin.tar.gz
+            binary: cc-audit
+          - platform: linux-arm64
+            artifact: cc-audit-${{ github.ref_name }}-aarch64-unknown-linux-gnu.tar.gz
+            binary: cc-audit
+          - platform: linux-x64
+            artifact: cc-audit-${{ github.ref_name }}-x86_64-unknown-linux-gnu.tar.gz
+            binary: cc-audit
+          - platform: linux-x64-musl
+            artifact: cc-audit-${{ github.ref_name }}-x86_64-unknown-linux-musl.tar.gz
+            binary: cc-audit
+          - platform: win32-x64
+            artifact: cc-audit-${{ github.ref_name }}-x86_64-pc-windows-msvc.zip
+            binary: cc-audit.exe
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Download release artifact
+        run: |
+          gh release download ${{ github.ref_name }} \
+            --pattern "${{ matrix.artifact }}" \
+            --dir ./tmp
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract binary
+        run: |
+          mkdir -p npm/${{ matrix.platform }}/bin
+          cd tmp
+          if [[ "${{ matrix.artifact }}" == *.zip ]]; then
+            unzip *.zip
+          else
+            tar -xzf *.tar.gz
+          fi
+          mv ${{ matrix.binary }} ../npm/${{ matrix.platform }}/bin/
+          chmod +x ../npm/${{ matrix.platform }}/bin/* || true
+
+      - name: Update version in package.json
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cd npm/${{ matrix.platform }}
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json
+          mv tmp.json package.json
+
+      - name: Publish platform package
+        run: |
+          cd npm/${{ matrix.platform }}
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+  publish-main:
+    name: Publish main package
+    needs: publish-platforms
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update version in package.json
+        run: |
+          VERSION="${{ github.ref_name }}"
+          VERSION="${VERSION#v}"
+          cd npm/cc-audit
+          jq --arg v "$VERSION" '.version = $v' package.json > tmp.json
+          mv tmp.json package.json
+          jq --arg v "$VERSION" '.optionalDependencies |= with_entries(.value = $v)' package.json > tmp.json
+          mv tmp.json package.json
+
+      - name: Publish main package
+        run: |
+          cd npm/cc-audit
+          npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -34,17 +34,39 @@ This creates a significant security gap. Users must trust third-party artifacts 
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
 ```bash
-# From crates.io (Recommended)
-cargo install cc-audit
-
-# From source
-git clone https://github.com/ryo-ebata/cc-audit.git
-cd cc-audit && cargo install --path .
-
-# Homebrew (macOS/Linux)
 brew install ryo-ebata/tap/cc-audit
 ```
+
+### Cargo (Rust)
+
+```bash
+cargo install cc-audit
+```
+
+### npm (Node.js)
+
+```bash
+# Run directly
+npx @cc-audit/cc-audit ./my-skill/
+
+# Or install globally
+npm install -g @cc-audit/cc-audit
+cc-audit ./my-skill/
+```
+
+### From Source
+
+```bash
+git clone https://github.com/ryo-ebata/cc-audit.git
+cd cc-audit && cargo install --path .
+```
+
+### Direct Download
+
+Download binaries from [GitHub Releases](https://github.com/ryo-ebata/cc-audit/releases).
 
 ## Quick Start
 

--- a/homebrew/cc-audit.rb
+++ b/homebrew/cc-audit.rb
@@ -1,0 +1,42 @@
+# Homebrew Formula for cc-audit
+# Copy this file to homebrew-tap/Formula/cc-audit.rb after updating SHA256 values
+#
+# To calculate SHA256 from release assets:
+#   curl -sL https://github.com/ryo-ebata/cc-audit/releases/download/vX.Y.Z/cc-audit-vX.Y.Z-TARGET.tar.gz | shasum -a 256
+#
+class CcAudit < Formula
+  desc "Security auditor for Claude Code skills, hooks, and MCP servers"
+  homepage "https://github.com/ryo-ebata/cc-audit"
+  version "0.4.1"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/ryo-ebata/cc-audit/releases/download/v#{version}/cc-audit-v#{version}-aarch64-apple-darwin.tar.gz"
+      sha256 "REPLACE_WITH_ACTUAL_SHA256_DARWIN_ARM64"
+    end
+    on_intel do
+      url "https://github.com/ryo-ebata/cc-audit/releases/download/v#{version}/cc-audit-v#{version}-x86_64-apple-darwin.tar.gz"
+      sha256 "REPLACE_WITH_ACTUAL_SHA256_DARWIN_X64"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/ryo-ebata/cc-audit/releases/download/v#{version}/cc-audit-v#{version}-aarch64-unknown-linux-gnu.tar.gz"
+      sha256 "REPLACE_WITH_ACTUAL_SHA256_LINUX_ARM64"
+    end
+    on_intel do
+      url "https://github.com/ryo-ebata/cc-audit/releases/download/v#{version}/cc-audit-v#{version}-x86_64-unknown-linux-gnu.tar.gz"
+      sha256 "REPLACE_WITH_ACTUAL_SHA256_LINUX_X64"
+    end
+  end
+
+  def install
+    bin.install "cc-audit"
+  end
+
+  test do
+    assert_match "cc-audit", shell_output("#{bin}/cc-audit --version")
+  end
+end

--- a/npm/cc-audit/README.md
+++ b/npm/cc-audit/README.md
@@ -1,0 +1,41 @@
+# @cc-audit/cc-audit
+
+Security auditor for Claude Code skills, hooks, and MCP servers.
+
+## Installation
+
+```bash
+# Run directly with npx
+npx @cc-audit/cc-audit ./my-skill/
+
+# Or install globally
+npm install -g @cc-audit/cc-audit
+cc-audit ./my-skill/
+```
+
+## Usage
+
+```bash
+# Audit a Claude Code skill directory
+cc-audit ./my-skill/
+
+# Watch for changes
+cc-audit watch ./my-skill/
+
+# Output as JSON
+cc-audit --format json ./my-skill/
+```
+
+## Supported Platforms
+
+- macOS (Apple Silicon and Intel)
+- Linux (x64, ARM64, musl/Alpine)
+- Windows (x64)
+
+## Documentation
+
+For full documentation, visit the [GitHub repository](https://github.com/ryo-ebata/cc-audit).
+
+## License
+
+MIT

--- a/npm/cc-audit/bin/cc-audit
+++ b/npm/cc-audit/bin/cc-audit
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+
+const { execFileSync } = require('child_process');
+const { getBinaryPath } = require('../src/index.js');
+
+const binaryPath = getBinaryPath();
+
+try {
+  execFileSync(binaryPath, process.argv.slice(2), {
+    stdio: 'inherit',
+  });
+} catch (error) {
+  if (error.status !== undefined) {
+    process.exit(error.status);
+  }
+  throw error;
+}

--- a/npm/cc-audit/package.json
+++ b/npm/cc-audit/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@cc-audit/cc-audit",
+  "version": "0.4.1",
+  "description": "Security auditor for Claude Code skills, hooks, and MCP servers",
+  "keywords": [
+    "claude",
+    "claude-code",
+    "security",
+    "audit",
+    "mcp",
+    "skills"
+  ],
+  "author": "Ryo Ebata",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "homepage": "https://github.com/ryo-ebata/cc-audit",
+  "bugs": {
+    "url": "https://github.com/ryo-ebata/cc-audit/issues"
+  },
+  "bin": {
+    "cc-audit": "./bin/cc-audit"
+  },
+  "main": "./src/index.js",
+  "files": [
+    "bin",
+    "src"
+  ],
+  "engines": {
+    "node": ">=16"
+  },
+  "optionalDependencies": {
+    "@cc-audit/darwin-arm64": "0.4.1",
+    "@cc-audit/darwin-x64": "0.4.1",
+    "@cc-audit/linux-arm64": "0.4.1",
+    "@cc-audit/linux-x64": "0.4.1",
+    "@cc-audit/linux-x64-musl": "0.4.1",
+    "@cc-audit/win32-x64": "0.4.1"
+  }
+}

--- a/npm/cc-audit/src/index.js
+++ b/npm/cc-audit/src/index.js
@@ -1,0 +1,76 @@
+const path = require('path');
+const fs = require('fs');
+
+const PLATFORMS = {
+  'darwin-arm64': '@cc-audit/darwin-arm64',
+  'darwin-x64': '@cc-audit/darwin-x64',
+  'linux-arm64': '@cc-audit/linux-arm64',
+  'linux-x64': '@cc-audit/linux-x64',
+  'win32-x64': '@cc-audit/win32-x64',
+};
+
+function isMusl() {
+  if (process.platform !== 'linux') return false;
+
+  try {
+    const output = require('child_process').execSync('ldd --version 2>&1', {
+      encoding: 'utf8',
+    });
+    return output.includes('musl');
+  } catch {
+    try {
+      const release = fs.readFileSync('/etc/os-release', 'utf8');
+      return release.includes('Alpine');
+    } catch {
+      return false;
+    }
+  }
+}
+
+function getPlatformPackage() {
+  const platform = process.platform;
+  const arch = process.arch;
+
+  if (platform === 'linux' && arch === 'x64' && isMusl()) {
+    return '@cc-audit/linux-x64-musl';
+  }
+
+  const key = `${platform}-${arch}`;
+  const pkg = PLATFORMS[key];
+
+  if (!pkg) {
+    throw new Error(
+      `Unsupported platform: ${platform}-${arch}\n` +
+        `Supported platforms: ${Object.keys(PLATFORMS).join(', ')}, linux-x64-musl`
+    );
+  }
+
+  return pkg;
+}
+
+function getBinaryPath() {
+  const pkg = getPlatformPackage();
+
+  try {
+    const pkgPath = require.resolve(`${pkg}/package.json`);
+    const pkgDir = path.dirname(pkgPath);
+    const binaryName =
+      process.platform === 'win32' ? 'cc-audit.exe' : 'cc-audit';
+    const binaryPath = path.join(pkgDir, 'bin', binaryName);
+
+    if (!fs.existsSync(binaryPath)) {
+      throw new Error(`Binary not found: ${binaryPath}`);
+    }
+
+    return binaryPath;
+  } catch (error) {
+    if (error.code === 'MODULE_NOT_FOUND') {
+      throw new Error(
+        `Platform package not installed: ${pkg}\n` + `Run: npm install ${pkg}`
+      );
+    }
+    throw error;
+  }
+}
+
+module.exports = { getBinaryPath, getPlatformPackage };

--- a/npm/darwin-arm64/package.json
+++ b/npm/darwin-arm64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/darwin-arm64",
+  "version": "0.4.1",
+  "description": "cc-audit binary for macOS ARM64 (Apple Silicon)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["arm64"],
+  "files": ["bin"]
+}

--- a/npm/darwin-x64/package.json
+++ b/npm/darwin-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/darwin-x64",
+  "version": "0.4.1",
+  "description": "cc-audit binary for macOS x64 (Intel)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["darwin"],
+  "cpu": ["x64"],
+  "files": ["bin"]
+}

--- a/npm/linux-arm64/package.json
+++ b/npm/linux-arm64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/linux-arm64",
+  "version": "0.4.1",
+  "description": "cc-audit binary for Linux ARM64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["linux"],
+  "cpu": ["arm64"],
+  "files": ["bin"]
+}

--- a/npm/linux-x64-musl/package.json
+++ b/npm/linux-x64-musl/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/linux-x64-musl",
+  "version": "0.4.1",
+  "description": "cc-audit binary for Linux x64 (musl/Alpine)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin"]
+}

--- a/npm/linux-x64/package.json
+++ b/npm/linux-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/linux-x64",
+  "version": "0.4.1",
+  "description": "cc-audit binary for Linux x64 (glibc)",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["linux"],
+  "cpu": ["x64"],
+  "files": ["bin"]
+}

--- a/npm/win32-x64/package.json
+++ b/npm/win32-x64/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@cc-audit/win32-x64",
+  "version": "0.4.1",
+  "description": "cc-audit binary for Windows x64",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ryo-ebata/cc-audit.git"
+  },
+  "os": ["win32"],
+  "cpu": ["x64"],
+  "files": ["bin"]
+}


### PR DESCRIPTION
## Summary

- Add Homebrew formula and tap configuration for easy macOS/Linux installation
- Add npm package wrapper for cross-platform CLI distribution via Node.js
- Add npm-publish workflow for automated npm releases on GitHub Release
- Update README with comprehensive installation instructions for all distribution methods

## Installation Methods Added

1. **Homebrew** (macOS/Linux): `brew install ryo-ebata/tap/cc-audit`
2. **npm/npx** (Node.js): `npx @cc-audit/cc-audit` or `npm install -g @cc-audit/cc-audit`
3. **Cargo** (Rust): `cargo install cc-audit`
4. **From source**: Clone and build
5. **Direct download**: GitHub Releases binaries

## Test plan

- [ ] Verify Homebrew formula syntax is correct
- [ ] Test npm package locally with `npm pack` and install
- [ ] Verify npm-publish workflow triggers on release
- [ ] Test README installation instructions render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)