### PR TITLE
feat: CI automation, rule severity, and documentation improvements

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,6 +21,9 @@ jobs:
         id: release
         with:
           release-type: rust
+          # PAT を使用してPR作成権限の制限を回避
+          # GITHUB_TOKENではリポジトリ設定で許可されていない場合にPR作成が失敗する
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
   # CI が全てパスしたら Release PR を自動マージ
   auto-merge:
@@ -30,7 +33,7 @@ jobs:
     steps:
       - name: Enable auto-merge for Release PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           PR_NUMBER: ${{ fromJson(needs.release-please.outputs.pr).number }}
         run: |
           gh pr merge $PR_NUMBER --repo ${{ github.repository }} --auto --squash


### PR DESCRIPTION
## Summary

- **Rule severity configuration**: Add per-rule severity (error/warn/ignore) to control CI exit codes
- **CI automation**: Add release-please, commitlint, and auto-merge workflows
- **Documentation**: Add CI/CD examples, distribution guides, and configuration docs
- **CI fixes**: Fix benchmark comparison, self-audit workflow, and release-please permissions

## Changes

### Breaking Changes
- Default behavior now returns exit code 1 for ANY finding (previously only critical/high)

### New Features
- Rule severity levels (error/warn/ignore) in `.cc-audit.yaml`
- `--warn-only` and `--min-rule-severity` CLI options
- Terminal output shows [ERROR]/[WARN] labels

### CI/CD
- release-please for automated releases
- commitlint for conventional commits
- Local git hooks for commit message validation
- Fix benchmark comparison with fetch-depth: 0
- Fix self-audit workflow with result aggregation job
- Use PAT for release-please to bypass GITHUB_TOKEN restrictions

### Documentation
- `docs/CI.md` / `docs/CI.ja.md` - CI integration guide
- `docs/DISTRIBUTION.md` / `docs/DISTRIBUTION.ja.md` - Installation methods
- `examples/` - GitHub Actions, GitLab CI, pre-commit examples
- `.cc-audit.yaml` - Configuration template

## Test plan

- [x] All tests pass (995 tests)
- [x] Clippy checks pass
- [x] Integration tests updated
- [ ] Manual verification of release-please workflow (requires PAT secret)

🤖 Generated with [Claude Code](https://claude.com/claude-code)