### PR TITLE
fix: add last-release-sha to reset release-please versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "last-release-sha": "07e4bf9a7b5944ea47965220a839bb4327df7954",
   "packages": {
     ".": {
       "release-type": "rust",


### PR DESCRIPTION
## Summary

release-pleaseが不正なバージョン(v3.0.0)を提案していた問題を修正。

`last-release-sha`をv1.1.0のコミット(07e4bf9)に設定することで、
release-pleaseがそれ以降のコミットのみを考慮するようになります。

## Root Cause

- v2.0.0が誤ってリリースされ、その後v1.1.0に手動で戻された
- release-pleaseの内部状態がv2.0.0のままだったため、以前の`feat!:`コミットを検出してv3.0.0を提案していた

## Test plan

- [x] ビルド成功
- [x] テスト通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)