### PR TITLE
ci(release): add workflow_dispatch trigger for manual runs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to release-please workflow
- This allows manual triggering of release-please when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)