### PR TITLE
fix(release): force release version to 1.2.0

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "packages": {
     ".": {
       "release-type": "rust",
+      "release-as": "1.2.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary
- Add `release-as: 1.2.0` option to force the next release to be v1.2.0
- This overrides the automatic version calculation that was incorrectly proposing v3.0.0

## Reason
release-please was calculating v3.0.0 based on historical breaking change commits, even though those were already released as part of v1.1.0. This config change forces the correct version.

Note: After v1.2.0 is released, the `release-as` option should be removed to allow normal version calculation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)