### PR TITLE
fix(perf): add elapsed_ms timing to scan results

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -307,6 +307,7 @@ impl McpServer {
                     summary,
                     findings,
                     risk_score: Some(risk_score),
+                    elapsed_ms: 0,
                 };
                 Ok(json!({
                     "content": [{

--- a/src/output/formatter.rs
+++ b/src/output/formatter.rs
@@ -136,6 +136,7 @@ mod tests {
             },
             findings: Vec::new(),
             risk_score: None,
+            elapsed_ms: 0,
         }
     }
 

--- a/src/reporter/markdown.rs
+++ b/src/reporter/markdown.rs
@@ -363,6 +363,7 @@ mod tests {
                 warnings: 0,
             },
             risk_score: None,
+            elapsed_ms: 0,
         }
     }
 
@@ -406,6 +407,7 @@ mod tests {
                 warnings: 0,
             },
             risk_score: None,
+            elapsed_ms: 0,
         };
         let output = reporter.report(&result);
 
@@ -449,6 +451,7 @@ mod tests {
                 warnings: 0,
             },
             risk_score: None,
+            elapsed_ms: 0,
         };
         // Calculate risk score from the findings
         let mut result = result;
@@ -538,6 +541,7 @@ mod tests {
                 warnings: 1,
             },
             risk_score: None,
+            elapsed_ms: 0,
         };
         let output = reporter.report(&result);
 

--- a/src/reporter/terminal.rs
+++ b/src/reporter/terminal.rs
@@ -401,6 +401,7 @@ impl Reporter for TerminalReporter {
             result_text,
             if passed { 0 } else { 1 }
         ));
+        output.push_str(&format!("Elapsed: {}ms\n", result.elapsed_ms));
 
         output
     }

--- a/src/rules/types.rs
+++ b/src/rules/types.rs
@@ -414,6 +414,7 @@ pub struct ScanResult {
     pub findings: Vec<Finding>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub risk_score: Option<RiskScore>,
+    pub elapsed_ms: u64,
 }
 
 #[cfg(test)]

--- a/src/run/formatter.rs
+++ b/src/run/formatter.rs
@@ -125,6 +125,7 @@ mod tests {
             },
             findings: vec![],
             risk_score: None,
+            elapsed_ms: 0,
         }
     }
 

--- a/src/run/scanner.rs
+++ b/src/run/scanner.rs
@@ -39,6 +39,7 @@ fn run_scan_with_check_args_internal(
     args: &CheckArgs,
     preloaded_config: Option<Config>,
 ) -> Option<ScanResult> {
+    let start = std::time::Instant::now();
     let mut all_findings = Vec::new();
     let mut targets = Vec::new();
 
@@ -195,6 +196,7 @@ fn run_scan_with_check_args_internal(
         summary,
         findings: filtered_findings,
         risk_score: Some(risk_score),
+        elapsed_ms: start.elapsed().as_millis() as u64,
     })
 }
 

--- a/src/runtime/executor.rs
+++ b/src/runtime/executor.rs
@@ -67,6 +67,7 @@ impl ScanExecutor {
             },
             findings: Vec::new(),
             risk_score: None,
+            elapsed_ms: 0,
         })
     }
 }

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -17,6 +17,7 @@ pub mod fixtures {
             summary,
             findings,
             risk_score,
+            elapsed_ms: 0,
         }
     }
 


### PR DESCRIPTION
## Summary
- Add `elapsed_ms` field to `ScanResult` struct for scan execution time measurement
- Capture timing via `std::time::Instant` in `run_scan_with_check_args_internal`
- Display `Elapsed: XXms` in terminal reporter summary line

## Test plan
- [x] `cargo test` — all 1696 unit tests, 180 integration tests, 3 doc tests passed
- [ ] `cargo run -- check .` で `Elapsed: XXms` がターミナル出力に表示されることを確認
- [ ] `cargo run -- check . --format json` で JSON 出力に `elapsed_ms` が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)