### PR TITLE
fix(lint): add clippy config and fix non-idiomatic patterns

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,13 @@ harness = false
 # Coverage configuration
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage)'] }
+
+[lints.clippy]
+# プロダクションコードでの unwrap/expect/panic を段階的に排除するための lint 設定
+# 既存コードの修正が完了次第 "warn" に昇格予定
+unwrap_used = "allow"
+expect_used = "allow"
+panic = "allow"
+todo = "warn"
+dbg_macro = "warn"
+print_stderr = "allow"  # CLI のエラー出力で必要

--- a/src/engine/scanners/macros.rs
+++ b/src/engine/scanners/macros.rs
@@ -26,9 +26,9 @@
 #[macro_export]
 macro_rules! impl_scanner_builder {
     ($scanner:ty) => {
+        #[allow(dead_code)]
         impl $scanner {
             /// Creates a new scanner with default configuration.
-            #[allow(dead_code)]
             pub fn new() -> Self {
                 Self {
                     config: $crate::scanner::ScannerConfig::new(),
@@ -36,14 +36,12 @@ macro_rules! impl_scanner_builder {
             }
 
             /// Enables or disables comment skipping during scanning.
-            #[allow(dead_code)]
             pub fn with_skip_comments(mut self, skip: bool) -> Self {
                 self.config = self.config.with_skip_comments(skip);
                 self
             }
 
             /// Adds dynamic rules loaded from custom YAML files.
-            #[allow(dead_code)]
             pub fn with_dynamic_rules(mut self, rules: Vec<$crate::rules::DynamicRule>) -> Self {
                 self.config = self.config.with_dynamic_rules(rules);
                 self
@@ -51,7 +49,6 @@ macro_rules! impl_scanner_builder {
 
             /// Enables or disables strict secrets mode.
             /// When enabled, dummy key heuristics are disabled for test files.
-            #[allow(dead_code)]
             pub fn with_strict_secrets(mut self, strict: bool) -> Self {
                 self.config = self.config.with_strict_secrets(strict);
                 self
@@ -59,14 +56,12 @@ macro_rules! impl_scanner_builder {
 
             /// Enables or disables recursive scanning.
             /// When disabled, only scans the immediate directory (max_depth = 1).
-            #[allow(dead_code)]
             pub fn with_recursive(mut self, recursive: bool) -> Self {
                 self.config = self.config.with_recursive(recursive);
                 self
             }
 
             /// Sets a progress callback that will be called for each scanned file.
-            #[allow(dead_code)]
             pub fn with_progress_callback(
                 mut self,
                 callback: $crate::engine::scanner::ProgressCallback,

--- a/src/handlers/pin.rs
+++ b/src/handlers/pin.rs
@@ -17,7 +17,7 @@ pub fn handle_pin(args: &CheckArgs, verbose: bool) -> ExitCode {
     // Find MCP config file
     let mcp_path = find_mcp_config(&target_path);
 
-    if mcp_path.is_none() {
+    let Some(mcp_path) = mcp_path else {
         eprintln!(
             "{} No MCP configuration file found in {}",
             "Error:".red().bold(),
@@ -28,9 +28,7 @@ pub fn handle_pin(args: &CheckArgs, verbose: bool) -> ExitCode {
             "Looked for: mcp.json, .mcp.json, settings.json".dimmed()
         );
         return ExitCode::from(2);
-    }
-
-    let mcp_path = mcp_path.unwrap();
+    };
 
     // Check if we're updating existing pins
     if args.pin_update {
@@ -103,16 +101,14 @@ pub fn handle_pin_verify(args: &CheckArgs) -> ExitCode {
     // Find MCP config file
     let mcp_path = find_mcp_config(&target_path);
 
-    if mcp_path.is_none() {
+    let Some(mcp_path) = mcp_path else {
         eprintln!(
             "{} No MCP configuration file found in {}",
             "Error:".red().bold(),
             target_path.display()
         );
         return ExitCode::from(2);
-    }
-
-    let mcp_path = mcp_path.unwrap();
+    };
 
     // Verify pins against current config
     match pins.verify(&mcp_path) {

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -377,17 +377,14 @@ impl McpServer {
             })?;
 
         // Check if rule exists
-        let rule = self.rule_engine.get_rule(rule_id);
-        if rule.is_none() {
+        let Some(rule) = self.rule_engine.get_rule(rule_id) else {
             return Ok(json!({
                 "content": [{
                     "type": "text",
                     "text": format!("Rule '{}' not found", rule_id)
                 }]
             }));
-        }
-
-        let rule = rule.unwrap();
+        };
 
         // Check if any pattern matches
         let mut matches = false;
@@ -474,17 +471,14 @@ impl McpServer {
             })?;
 
         // Create a mock finding for the fixer
-        let rule = self.rule_engine.get_rule(finding_id);
-        if rule.is_none() {
+        let Some(rule) = self.rule_engine.get_rule(finding_id) else {
             return Ok(json!({
                 "content": [{
                     "type": "text",
                     "text": format!("No fix suggestion available for rule '{}'", finding_id)
                 }]
             }));
-        }
-
-        let rule = rule.unwrap();
+        };
         let finding = Finding {
             id: finding_id.to_string(),
             severity: rule.severity,


### PR DESCRIPTION
## Summary
- `Cargo.toml` に `[lints.clippy]` セクション追加 (`todo`, `dbg_macro` を warn に設定)
- `pin.rs` と `mcp_server.rs` の `is_none()` + `.unwrap()` パターンを `let-else` に変更 (計4箇所)
- `macros.rs` の個別 `#[allow(dead_code)]` を impl ブロックレベルに集約

Closes #8, #10, #12

## Test plan
- [x] `cargo build` 成功
- [x] `cargo test` 全テスト通過 (1696 + 107 + 77)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)