### PR TITLE
fix(ci): Fix Security workflow permissions and CVE update timeout

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,11 @@ on:
     # Run weekly on Monday at 00:00 UTC
     - cron: '0 0 * * 1'
 
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/scripts/update-cve-database.py
+++ b/scripts/update-cve-database.py
@@ -87,6 +87,9 @@ def fetch_nvd_cves(keyword: str, days_back: int = 30) -> list[dict[str, Any]]:
     except URLError as e:
         print(f"URL Error fetching CVEs for '{keyword}': {e.reason}", file=sys.stderr)
         return []
+    except TimeoutError as e:
+        print(f"Timeout fetching CVEs for '{keyword}': {e}", file=sys.stderr)
+        return []
     except json.JSONDecodeError as e:
         print(f"JSON decode error for '{keyword}': {e}", file=sys.stderr)
         return []


### PR DESCRIPTION
## 問題

2つのCIワークフローが失敗していました:

### 1. Security CI - Advisory Database ジョブ
- エラー: `Resource not accessible by integration`
- 原因: `rustsec/audit-check@v2` がチェック結果を作成する権限を持っていない
- ワークフローに `permissions` セクションがなかったため

### 2. CVE Database Update CI  
- エラー: `TimeoutError: The read operation timed out`
- 原因: NVD APIへのリクエストがタイムアウト
- TimeoutErrorのハンドリングが不足していたため、ワークフロー全体が失敗

## 変更内容

### `.github/workflows/security.yml`
- 必要な権限を追加:
  - `contents: read` - リポジトリの読み取り
  - `checks: write` - チェック結果の作成
  - `pull-requests: write` - PR へのアノテーション追加

### `scripts/update-cve-database.py`
- `TimeoutError` の明示的なエラーハンドリングを追加
- タイムアウトが発生しても処理を継続し、次のキーワード検索に進むように修正

## テスト

- [x] Pythonスクリプトの構文チェック完了
- [x] 全てのRustテストが成功
- [x] pre-commit/pre-push フックが成功

## 関連リンク

- Fixes: https://github.com/ryo-ebata/cc-audit/actions/runs/21568674727
- Fixes: https://github.com/ryo-ebata/cc-audit/actions/runs/21473136922

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)