### PR TITLE
ci(cve): use GitHub App token so auto-created PRs trigger CI

### DIFF
--- a/.github/workflows/cve-update.yml
+++ b/.github/workflows/cve-update.yml
@@ -133,10 +133,71 @@ jobs:
             security
             automated
 
-      - name: Enable auto-merge
+      # Wait for every required status check to conclude, then merge.
+      #
+      # We deliberately do NOT use `gh pr merge --auto`: enabling auto-merge
+      # immediately after force-pushing the PR branch hits a race where the
+      # freshly pushed HEAD has no check runs attached yet, so branch
+      # protection sees zero pending/failing required checks and merges the PR
+      # within seconds -- before CI even starts. Instead we poll the status
+      # rollup until all required contexts are present AND completed, and merge
+      # only if they all passed.
+      - name: Wait for required checks and merge
         if: steps.create-pr.outputs.pull-request-number
+        timeout-minutes: 30
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR: ${{ steps.create-pr.outputs.pull-request-number }}
         run: |
-          gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
-            --auto --squash
+          # Required status checks for `main`. Keep this list in sync with the
+          # `protect-main-branch` repository ruleset; a check missing here would
+          # be skipped, one listed but no longer required would hang until the
+          # 30-minute step timeout fires (fail-safe: no merge on timeout).
+          REQUIRED=(
+            "CI Result"
+            "Security Result"
+            "Performance Result"
+            "Semver Result"
+            "Terraform Result"
+            "Self Audit Result"
+            "MSRV Result"
+          )
+
+          echo "Waiting for required checks to conclude on PR #${PR}..."
+          while true; do
+            # name<TAB>outcome, where outcome is the CheckRun conclusion or the
+            # StatusContext state (empty/PENDING while still running).
+            ROLLUP=$(gh pr view "$PR" --json statusCheckRollup \
+              -q '.statusCheckRollup[]? | [(.name // .context), (.conclusion // .state)] | @tsv')
+
+            all_done=true
+            failed=false
+            for name in "${REQUIRED[@]}"; do
+              outcome=$(printf '%s\n' "$ROLLUP" | awk -F'\t' -v n="$name" '$1==n{print $2; exit}')
+              case "$outcome" in
+                SUCCESS)
+                  ;;
+                "" | PENDING | null)
+                  all_done=false
+                  echo "  [pending] ${name}"
+                  ;;
+                *)
+                  failed=true
+                  echo "  [FAILED ] ${name} -> ${outcome}"
+                  ;;
+              esac
+            done
+
+            if [ "$failed" = true ]; then
+              echo "::error::Required check(s) failed; not merging PR #${PR}."
+              exit 1
+            fi
+            if [ "$all_done" = true ]; then
+              echo "All required checks passed."
+              break
+            fi
+
+            sleep 15
+          done
+
+          gh pr merge "$PR" --squash --delete-branch

--- a/.github/workflows/cve-update.yml
+++ b/.github/workflows/cve-update.yml
@@ -22,6 +22,13 @@ jobs:
   update-cve-database:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
@@ -98,7 +105,7 @@ jobs:
         if: steps.check-changes.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: |
             fix(cve): update CVE database (v${{ steps.bump-version.outputs.new_version }})
 
@@ -129,7 +136,7 @@ jobs:
       - name: Enable auto-merge
         if: steps.create-pr.outputs.pull-request-number
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh pr merge ${{ steps.create-pr.outputs.pull-request-number }} \
             --auto --squash

--- a/.github/workflows/cve-update.yml
+++ b/.github/workflows/cve-update.yml
@@ -106,6 +106,10 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # Always target main. Without this, the base defaults to the ref the
+          # workflow runs on, so a manual workflow_dispatch from a feature
+          # branch would open (and auto-merge) the PR against that branch.
+          base: main
           commit-message: |
             fix(cve): update CVE database (v${{ steps.bump-version.outputs.new_version }})
 


### PR DESCRIPTION
## 問題

CVE更新ワークフローが `GITHUB_TOKEN` でPRを作成していたため、作られたPRが他のワークフロー（CI）をトリガーせず、required checks が永久に pending → auto-merge が `BLOCKED` のまま放置されていた（例: PR #89 が 2026-02-03 から stuck）。

これは GitHub の仕様（`GITHUB_TOKEN` 作成のイベントは再帰的ワークフロー実行を防ぐため他ワークフローを起動しない）。

## 修正

`actions/create-github-app-token@v2` で App installation token を生成し、PR作成と auto-merge に使用。App token 製のPRは通常イベントとして扱われCIが走る。

## 検証

`workflow_dispatch` で `fix/cve-app-token` 上を実行し、全ステップ success。生成されたCVE PRで**CIが実際にトリガーされることを確認**（従来は "no checks reported"）。

## 前提

リポジトリシークレット `APP_ID` / `APP_PRIVATE_KEY` を設定済み（GitHub App: contents:write, pull-requests:write）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)