### PR TITLE
build(deps): fix Dependabot commit type so CI (commitlint) passes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,10 @@ updates:
       day: "monday"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "deps(rust)"
+      # Use a Conventional Commits type accepted by commitlint / the
+      # semantic-PR check. "deps" is not a valid type, so dependency updates
+      # are classified as "build" (per the project's commit-type convention).
+      prefix: "build(deps)"
     labels:
       - "dependencies"
       - "rust"
@@ -28,7 +31,9 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     commit-message:
-      prefix: "deps(actions)"
+      # Same rationale as the cargo ecosystem above: "build" is a valid
+      # Conventional Commits type, "deps" is not.
+      prefix: "build(deps)"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
## Problem

Every Dependabot PR (#106, #107, #108) fails the **Commitlint** check:

```
##[error]Unknown release type "deps" found in pull request title
"deps(actions): bump the actions group across 1 directory with 9 updates".
```

Root cause: `.github/dependabot.yml` used `prefix: "deps(rust)"` /
`prefix: "deps(actions)"`, but `deps` is **not** an allowed Conventional
Commits type. Both linters reject it:
- `amannn/action-semantic-pull-request` (PR title)
- `wagoid/commitlint-github-action` (commit messages)

## Fix

Switch the Dependabot commit prefix to `build(deps)`. `build` is the
project's Conventional Commits type for dependency / build-system changes
(per CLAUDE.md), and it is accepted by both linters. Scope `deps` is allowed
(no scope-enum rule; `requireScope: false`).

## Follow-up (manual)

Existing Dependabot PRs keep their old `deps(...)` titles until regenerated.
After this merges, comment `@dependabot recreate` on #106 / #107 / #108 so
they rebase onto the updated main and regenerate with the `build(deps)`
prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)