### PR TITLE
feat(rules): add EX-018 cloud metadata + PE-009 linker hijacking

### DIFF
--- a/src/rules/builtin/exfiltration.rs
+++ b/src/rules/builtin/exfiltration.rs
@@ -19,6 +19,7 @@ pub fn rules() -> Vec<Rule> {
         ex_015(),
         ex_016(),
         ex_017(),
+        ex_018(),
     ]
 }
 
@@ -565,6 +566,35 @@ fn ex_017() -> Rule {
         cwe_ids: &["CWE-200", "CWE-522"],
     }
 }
+
+fn ex_018() -> Rule {
+    Rule {
+        id: "EX-018",
+        name: "Cloud instance metadata access",
+        description: "Detects access to cloud instance metadata endpoints (IMDS), commonly abused via SSRF to steal short-lived instance credentials (MITRE T1552.005)",
+        severity: Severity::Critical,
+        category: Category::Exfiltration,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // AWS/Azure/OpenStack link-local IMDS address
+            Regex::new(r"169\.254\.169\.254").expect("EX-018: invalid regex"),
+            // GCP metadata server hostname
+            Regex::new(r"metadata\.google\.internal").expect("EX-018: invalid regex"),
+            // Alibaba Cloud metadata address
+            Regex::new(r"100\.100\.100\.200").expect("EX-018: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("EX-018: invalid regex"),
+        ],
+        message: "Cloud instance metadata (IMDS) access detected. Artifacts have no legitimate reason to query the metadata endpoint; it is a common credential-theft target.",
+        recommendation: "Remove access to the metadata endpoint. If cloud credentials are needed, use a scoped, audited mechanism — never query IMDS directly from an artifact.",
+        fix_hint: Some(
+            "Remove requests to 169.254.169.254 / metadata.google.internal. Enforce IMDSv2 and block metadata access from untrusted code.",
+        ),
+        cwe_ids: &["CWE-918", "CWE-200"],
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -800,5 +830,43 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/ex_017.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("ex_017", findings);
+    }
+
+    #[test]
+    fn test_ex_018() {
+        let rule = ex_018();
+        let test_cases = vec![
+            // Malicious: cloud metadata (IMDS) endpoints
+            (
+                "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+                true,
+            ),
+            (
+                "curl -H \"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+                true,
+            ),
+            ("wget -qO- http://100.100.100.200/latest/meta-data/", true),
+            ("curl -s http://169.254.169.254/latest/api/token", true),
+            // Benign: unrelated hosts and link-local addresses
+            ("curl https://api.example.com/metadata", false),
+            ("ping 169.254.1.1", false),
+            ("curl http://100.100.100.100/status", false),
+            ("echo \"fetching build metadata from registry\"", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "EX-018: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_ex_018() {
+        let rule = ex_018();
+        let content = include_str!("../../../tests/fixtures/rules/ex_018.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("ex_018", findings);
     }
 }

--- a/src/rules/builtin/privilege.rs
+++ b/src/rules/builtin/privilege.rs
@@ -11,6 +11,7 @@ pub fn rules() -> Vec<Rule> {
         pe_006(),
         pe_007(),
         pe_008(),
+        pe_009(),
     ]
 }
 
@@ -243,6 +244,41 @@ fn pe_008() -> Rule {
     }
 }
 
+fn pe_009() -> Rule {
+    Rule {
+        id: "PE-009",
+        name: "Dynamic linker hijacking",
+        description: "Detects shared-library injection via /etc/ld.so.preload writes or LD_PRELOAD pointing at writable, relative, or bare paths (MITRE T1574.006)",
+        severity: Severity::Critical,
+        category: Category::PrivilegeEscalation,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Any reference to the global preload file (writes load a lib into every process)
+            Regex::new(r"/etc/ld\.so\.preload").expect("PE-009: invalid regex"),
+            // LD_PRELOAD from a world-writable/temp directory
+            Regex::new(r"LD_PRELOAD\s*=\s*\S*/(tmp|dev/shm|var/tmp)/\S*\.so")
+                .expect("PE-009: invalid regex"),
+            // LD_PRELOAD from a relative path (current/parent dir)
+            Regex::new(r"LD_PRELOAD\s*=\s*(\./|\.\./)").expect("PE-009: invalid regex"),
+            // LD_PRELOAD of a bare filename (resolved from the current directory)
+            Regex::new(r"LD_PRELOAD\s*=\s*[A-Za-z0-9_.-]+\.so\b").expect("PE-009: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("PE-009: invalid regex"),
+            // Read-only inspection of the preload file
+            Regex::new(r"^\s*(cat|less|stat|head|tail|grep|ls)\s+[^\n]*/etc/ld\.so\.preload")
+                .expect("PE-009: invalid regex"),
+        ],
+        message: "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+        recommendation: "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths.",
+        fix_hint: Some(
+            "Delete /etc/ld.so.preload writes and untrusted LD_PRELOAD assignments; load only vetted system libraries by absolute path.",
+        ),
+        cwe_ids: &["CWE-426", "CWE-114"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,5 +450,41 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/pe_008.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("pe_008", findings);
+    }
+
+    #[test]
+    fn test_pe_009_detects_linker_hijacking() {
+        let rule = pe_009();
+        let test_cases = vec![
+            // Malicious: ld.so.preload writes and untrusted LD_PRELOAD
+            ("echo /tmp/evil.so > /etc/ld.so.preload", true),
+            ("LD_PRELOAD=/tmp/rootkit.so ./app", true),
+            ("LD_PRELOAD=./evil.so program", true),
+            ("export LD_PRELOAD=evil.so", true),
+            ("echo \"/dev/shm/x.so\" | tee /etc/ld.so.preload", true),
+            // Benign: absolute system lib, read-only inspection, unrelated vars
+            (
+                "LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so myprogram",
+                false,
+            ),
+            ("cat /etc/ld.so.preload", false),
+            ("export LD_LIBRARY_PATH=/opt/lib", false),
+            ("ldconfig -p", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "PE-009: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_pe_009() {
+        let rule = pe_009();
+        let content = include_str!("../../../tests/fixtures/rules/pe_009.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("pe_009", findings);
     }
 }

--- a/tests/fixtures/rules/ex_018.snap
+++ b/tests/fixtures/rules/ex_018.snap
@@ -1,0 +1,50 @@
+---
+source: src/rules/builtin/exfiltration.rs
+expression: findings
+---
+[
+  {
+    "id": "EX-018",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Cloud instance metadata access",
+    "line": 7,
+    "code": "curl http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+    "message": "Cloud instance metadata (IMDS) access detected. Artifacts have no legitimate reason to query the metadata endpoint; it is a common credential-theft target.",
+    "recommendation": "Remove access to the metadata endpoint. If cloud credentials are needed, use a scoped, audited mechanism — never query IMDS directly from an artifact."
+  },
+  {
+    "id": "EX-018",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Cloud instance metadata access",
+    "line": 8,
+    "code": "curl -H \"Metadata-Flavor: Google\" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token",
+    "message": "Cloud instance metadata (IMDS) access detected. Artifacts have no legitimate reason to query the metadata endpoint; it is a common credential-theft target.",
+    "recommendation": "Remove access to the metadata endpoint. If cloud credentials are needed, use a scoped, audited mechanism — never query IMDS directly from an artifact."
+  },
+  {
+    "id": "EX-018",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Cloud instance metadata access",
+    "line": 9,
+    "code": "wget -qO- http://100.100.100.200/latest/meta-data/",
+    "message": "Cloud instance metadata (IMDS) access detected. Artifacts have no legitimate reason to query the metadata endpoint; it is a common credential-theft target.",
+    "recommendation": "Remove access to the metadata endpoint. If cloud credentials are needed, use a scoped, audited mechanism — never query IMDS directly from an artifact."
+  },
+  {
+    "id": "EX-018",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Cloud instance metadata access",
+    "line": 10,
+    "code": "curl -s http://169.254.169.254/latest/api/token",
+    "message": "Cloud instance metadata (IMDS) access detected. Artifacts have no legitimate reason to query the metadata endpoint; it is a common credential-theft target.",
+    "recommendation": "Remove access to the metadata endpoint. If cloud credentials are needed, use a scoped, audited mechanism — never query IMDS directly from an artifact."
+  }
+]

--- a/tests/fixtures/rules/ex_018.txt
+++ b/tests/fixtures/rules/ex_018.txt
@@ -1,0 +1,16 @@
+# EX-018: Cloud instance metadata access
+# Test cases for snapshot testing
+# Detects access to cloud instance metadata endpoints (IMDS), commonly abused
+# to steal instance credentials via SSRF (MITRE T1552.005).
+
+# === Cases that SHOULD be detected ===
+curl http://169.254.169.254/latest/meta-data/iam/security-credentials/
+curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token
+wget -qO- http://100.100.100.200/latest/meta-data/
+curl -s http://169.254.169.254/latest/api/token
+
+# === Cases that should NOT be detected (benign) ===
+curl https://api.example.com/metadata
+ping 169.254.1.1
+curl http://100.100.100.100/status
+echo "fetching build metadata from registry"

--- a/tests/fixtures/rules/pe_009.snap
+++ b/tests/fixtures/rules/pe_009.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/privilege.rs
+expression: findings
+---
+[
+  {
+    "id": "PE-009",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Dynamic linker hijacking",
+    "line": 7,
+    "code": "echo /tmp/evil.so > /etc/ld.so.preload",
+    "message": "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+    "recommendation": "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths."
+  },
+  {
+    "id": "PE-009",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Dynamic linker hijacking",
+    "line": 8,
+    "code": "LD_PRELOAD=/tmp/rootkit.so ./app",
+    "message": "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+    "recommendation": "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths."
+  },
+  {
+    "id": "PE-009",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Dynamic linker hijacking",
+    "line": 9,
+    "code": "LD_PRELOAD=./evil.so program",
+    "message": "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+    "recommendation": "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths."
+  },
+  {
+    "id": "PE-009",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Dynamic linker hijacking",
+    "line": 10,
+    "code": "export LD_PRELOAD=evil.so",
+    "message": "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+    "recommendation": "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths."
+  },
+  {
+    "id": "PE-009",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Dynamic linker hijacking",
+    "line": 11,
+    "code": "echo \"/dev/shm/x.so\" | tee /etc/ld.so.preload",
+    "message": "Dynamic linker hijacking detected: a shared library is being injected via /etc/ld.so.preload or an untrusted LD_PRELOAD path.",
+    "recommendation": "Remove the preload injection. Artifacts must not write /etc/ld.so.preload or preload libraries from writable/relative paths."
+  }
+]

--- a/tests/fixtures/rules/pe_009.txt
+++ b/tests/fixtures/rules/pe_009.txt
@@ -1,0 +1,17 @@
+# PE-009: Dynamic linker hijacking (LD_PRELOAD / ld.so.preload)
+# Test cases for snapshot testing
+# Detects shared-library injection via /etc/ld.so.preload writes or LD_PRELOAD
+# pointing at writable/relative/bare paths (MITRE T1574.006).
+
+# === Cases that SHOULD be detected ===
+echo /tmp/evil.so > /etc/ld.so.preload
+LD_PRELOAD=/tmp/rootkit.so ./app
+LD_PRELOAD=./evil.so program
+export LD_PRELOAD=evil.so
+echo "/dev/shm/x.so" | tee /etc/ld.so.preload
+
+# === Cases that should NOT be detected (benign) ===
+LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so myprogram
+cat /etc/ld.so.preload
+export LD_LIBRARY_PATH=/opt/lib
+ldconfig -p


### PR DESCRIPTION
## Summary

Continues the detection-rule expansion loop. Two new rules for high-value attacker techniques not previously covered, each with malicious + benign fixtures and a passing false-positive gate.

| Rule | Technique | Severity | MITRE |
|------|-----------|----------|-------|
| **EX-018** Cloud instance metadata access | IMDS endpoint access (`169.254.169.254`, `metadata.google.internal`, `100.100.100.200`) — SSRF-based instance-credential theft | Critical | T1552.005 |
| **PE-009** Dynamic linker hijacking | `/etc/ld.so.preload` writes and `LD_PRELOAD` from writable/relative/bare paths | Critical | T1574.006 |

Rule count **106 → 108**.

## Duplicate checks

Verified against existing rules before writing: no rule touched `169.254.169.254`/metadata endpoints or `LD_PRELOAD`/`ld.so`. Also considered and dropped three candidates that overlapped existing coverage — a Trojan-Source rule (PI-003 already flags bidi overrides), a Docker `--cap-add` rule (DK-001 already flags `SYS_ADMIN`/`ALL`), and a paste-site exfil rule (EX-006 already flags `paste`/`termbin`/etc).

## Testing

- `cargo test` — 1719 lib tests green, new unit + snapshot tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — clean
- FP gate: each rule's benign fixture section produces zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)