### PR TITLE
docs(branching): document no-major-bump versioning policy

### DIFF
--- a/docs/BRANCHING.md
+++ b/docs/BRANCHING.md
@@ -117,6 +117,16 @@ Examples:
 - `v0.2.0` - New feature added
 - `v1.0.0` - Stable release / Breaking change
 
+### Versioning Policy
+
+As a rule, **we do not bump the major version.** Backward compatibility is a
+priority, so changes are expected to land as MINOR (`feat:`) or PATCH (`fix:`)
+releases. Avoid breaking changes; do not use `feat!:` / `fix!:` or a
+`BREAKING CHANGE:` footer (which release-please turns into a major bump) unless
+a major release has been explicitly agreed upon beforehand. When a change seems
+to require breaking behavior, prefer a backward-compatible path (deprecate, add
+an opt-in flag, or keep the old behavior as default) instead.
+
 ### Pre-release Tags
 
 ```


### PR DESCRIPTION
## Summary

Documents the project's versioning policy explicitly: **the major version is not bumped as a rule.**

Added a "Versioning Policy" subsection to `docs/BRANCHING.md`, right after the existing Version Format block (the natural home for release/versioning docs). It states:

- Changes should land as MINOR (`feat:`) or PATCH (`fix:`) releases.
- Do not use breaking-change markers (`feat!:` / `fix!:` / `BREAKING CHANGE:`), which release-please turns into a major bump, without prior agreement on a major release.
- Prefer backward-compatible alternatives (deprecate, opt-in flag, keep old default) over breaking behavior.

Docs-only change; no code or test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)