### PR TITLE
feat(rules): detect Slack API tokens in SL-007

### DIFF
--- a/src/rules/builtin/secrets.rs
+++ b/src/rules/builtin/secrets.rs
@@ -297,8 +297,8 @@ fn sl_006() -> Rule {
 fn sl_007() -> Rule {
     Rule {
         id: "SL-007",
-        name: "Slack webhook URL",
-        description: "Detects Slack incoming webhook URLs",
+        name: "Slack webhook URL or API token",
+        description: "Detects Slack incoming webhook URLs and Slack API tokens (bot/user/app-level)",
         severity: Severity::High,
         category: Category::SecretLeak,
         confidence: Confidence::Certain,
@@ -307,15 +307,22 @@ fn sl_007() -> Rule {
                 r"https://hooks\.slack\.com/services/T[A-Z0-9]{8,}/B[A-Z0-9]{8,}/[A-Za-z0-9]{20,}",
             )
             .expect("SL-007: invalid regex"),
+            // Bot/user/legacy tokens: xox[b|p|a|r|s]- followed by dash-separated
+            // numeric IDs and an alphanumeric secret. A Slack API token is strictly
+            // higher-impact than a webhook (full Web API: read messages/files, exfil).
+            Regex::new(r"\bxox[baprs]-[0-9A-Za-z]{10,}(-[0-9A-Za-z]{10,}){1,}\b")
+                .expect("SL-007: invalid regex"),
+            // App-level tokens: xapp-1-<app id>-<numeric>-<hex secret>.
+            Regex::new(r"\bxapp-1-[A-Z0-9]+-\d+-[0-9a-f]+\b").expect("SL-007: invalid regex"),
         ],
         exclusions: vec![
             // Test/example patterns
             Regex::new(r"(?i)test|mock|fake|dummy|example|fixture|sample")
                 .expect("SL-007: invalid regex"),
         ],
-        message: "Slack webhook URL detected. Anyone with this URL can post to your Slack channel.",
-        recommendation: "Rotate the webhook URL in Slack and use environment variables.",
-        fix_hint: Some("Use $SLACK_WEBHOOK_URL environment variable"),
+        message: "Slack webhook URL or API token detected. A bot/user token authenticates against the full Slack Web API (read messages/files, exfiltrate data).",
+        recommendation: "Rotate the webhook URL or token in Slack and load it from an environment variable.",
+        fix_hint: Some("Use $SLACK_WEBHOOK_URL / $SLACK_BOT_TOKEN environment variable"),
         cwe_ids: &["CWE-798", "CWE-200"],
     }
 }
@@ -563,6 +570,39 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_sl_007_detects_slack_api_tokens() {
+        let rule = sl_007();
+        let test_cases = vec![
+            // Should detect: Slack API tokens (higher-impact than webhook URL)
+            (
+                "SLACK_BOT_TOKEN=xoxb-2345678901-2345678901234-AbCdEfGhIjKlMnOpQrStUvWx",
+                true,
+            ),
+            (
+                "xoxp-1234567890-1234567890123-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx",
+                true,
+            ),
+            ("xapp-1-A01B2C3D4E5-1234567890123-abcdef0123456789", true),
+            // Should still detect the original webhook URL
+            (
+                "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX",
+                true,
+            ),
+            // Should not detect: documentation placeholder / benign
+            ("xoxb-your-token-here", false),
+            ("token = xoxb-example-placeholder", false),
+            ("not a slack token", false),
+        ];
+
+        for (input, should_match) in test_cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            let result = matched && !excluded;
+            assert_eq!(result, should_match, "Failed for input: {}", input);
+        }
+    }
+
     // Snapshot tests
     #[test]
     fn snapshot_sl_001() {
@@ -645,6 +685,14 @@ mod tests {
             !rule.patterns.iter().any(|p| p.is_match(&stripe_test)),
             "SL-011: must not match Stripe test key"
         );
+    }
+
+    #[test]
+    fn snapshot_sl_007() {
+        let rule = sl_007();
+        let content = include_str!("../../../tests/fixtures/rules/sl_007.txt");
+        let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
+        crate::assert_rule_snapshot!("sl_007", findings);
     }
 
     #[test]

--- a/tests/fixtures/rules/sl_007.snap
+++ b/tests/fixtures/rules/sl_007.snap
@@ -1,0 +1,50 @@
+---
+source: src/rules/builtin/secrets.rs
+expression: findings
+---
+[
+  {
+    "id": "SL-007",
+    "severity": "high",
+    "category": "secret_leak",
+    "confidence": "certain",
+    "name": "Slack webhook URL or API token",
+    "line": 8,
+    "code": "https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX",
+    "message": "Slack webhook URL or API token detected. A bot/user token authenticates against the full Slack Web API (read messages/files, exfiltrate data).",
+    "recommendation": "Rotate the webhook URL or token in Slack and load it from an environment variable."
+  },
+  {
+    "id": "SL-007",
+    "severity": "high",
+    "category": "secret_leak",
+    "confidence": "certain",
+    "name": "Slack webhook URL or API token",
+    "line": 9,
+    "code": "SLACK_BOT_TOKEN=xoxb-2345678901-2345678901234-AbCdEfGhIjKlMnOpQrStUvWx",
+    "message": "Slack webhook URL or API token detected. A bot/user token authenticates against the full Slack Web API (read messages/files, exfiltrate data).",
+    "recommendation": "Rotate the webhook URL or token in Slack and load it from an environment variable."
+  },
+  {
+    "id": "SL-007",
+    "severity": "high",
+    "category": "secret_leak",
+    "confidence": "certain",
+    "name": "Slack webhook URL or API token",
+    "line": 10,
+    "code": "xoxp-1234567890-1234567890123-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx",
+    "message": "Slack webhook URL or API token detected. A bot/user token authenticates against the full Slack Web API (read messages/files, exfiltrate data).",
+    "recommendation": "Rotate the webhook URL or token in Slack and load it from an environment variable."
+  },
+  {
+    "id": "SL-007",
+    "severity": "high",
+    "category": "secret_leak",
+    "confidence": "certain",
+    "name": "Slack webhook URL or API token",
+    "line": 11,
+    "code": "xapp-1-A01B2C3D4E5-1234567890123-abcdef0123456789",
+    "message": "Slack webhook URL or API token detected. A bot/user token authenticates against the full Slack Web API (read messages/files, exfiltrate data).",
+    "recommendation": "Rotate the webhook URL or token in Slack and load it from an environment variable."
+  }
+]

--- a/tests/fixtures/rules/sl_007.txt
+++ b/tests/fixtures/rules/sl_007.txt
@@ -1,0 +1,17 @@
+# SL-007: Slack webhook URL or API token
+# Test cases for snapshot testing
+# Detects Slack incoming webhook URLs and Slack API tokens (bot/user/app-level).
+# API tokens authenticate against the full Slack Web API (read messages/files,
+# exfiltrate workspace data), so they are strictly higher-impact than a webhook.
+
+# === Cases that SHOULD be detected ===
+https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXX
+SLACK_BOT_TOKEN=xoxb-2345678901-2345678901234-AbCdEfGhIjKlMnOpQrStUvWx
+xoxp-1234567890-1234567890123-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx
+xapp-1-A01B2C3D4E5-1234567890123-abcdef0123456789
+
+# === Cases that should NOT be detected (benign) ===
+xoxb-your-token-here
+SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}
+token = xoxb-example-placeholder
+not a slack token at all


### PR DESCRIPTION
## Summary

SL-007 previously matched only the Slack incoming-webhook URL, leaving bot/user/app-level **API tokens** (`xoxb-`/`xoxp-`/`xapp-`/…) undetected. A Slack API token is strictly higher-impact than a webhook: it authenticates against the full Slack Web API (read messages/files, exfiltrate workspace data), so a hardcoded token in an untrusted artifact scanned **clean** — the worst failure mode for a pre-install security gate.

## Changes

- Add token patterns to SL-007: `\bxox[baprs]-…` (bot/user/legacy) and `\bxapp-1-…` (app-level)
- Update rule name/description/message/fix_hint to reflect token coverage
- Add unit + snapshot tests; benign placeholders (`xoxb-your-token-here`, env-var refs) stay excluded

## Notes

Example tokens in fixtures/tests are synthetic and deliberately shaped to match cc-audit's own regex without tripping GitHub push-protection detectors (letter/short tails).

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)