### PR TITLE
fix(parser): match frontmatter delimiters on their own line (OP-001 evasion)

### DIFF
--- a/src/engine/scanners/skill/frontmatter.rs
+++ b/src/engine/scanners/skill/frontmatter.rs
@@ -1,76 +1,9 @@
-/// Parses YAML frontmatter from markdown files
-pub struct FrontmatterParser;
+//! Frontmatter parsing for skill files.
+//!
+//! Re-exports the canonical [`crate::parser::FrontmatterParser`] so there is a
+//! single, line-aware implementation of frontmatter extraction rather than a
+//! divergent copy. The previous duplicate used a raw `find("---")` substring
+//! search that truncated on a `---` inside a value, letting `allowed-tools: *`
+//! escape the scanned frontmatter and evade OP-001 (issue #131).
 
-impl FrontmatterParser {
-    /// Extract frontmatter content from a markdown file
-    ///
-    /// Frontmatter is delimited by `---` at the start and end.
-    /// Returns None if no valid frontmatter is found.
-    ///
-    /// # Example
-    /// ```ignore
-    /// let content = "---\nname: test\n---\n# Content";
-    /// let frontmatter = FrontmatterParser::extract(content);
-    /// assert_eq!(frontmatter, Some("name: test\n"));
-    /// ```
-    pub fn extract(content: &str) -> Option<&str> {
-        content.strip_prefix("---").and_then(|after_start| {
-            after_start
-                .find("---")
-                .map(|end_idx| &after_start[..end_idx])
-        })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_valid_frontmatter() {
-        let content = "---\nname: test\ndescription: A test\n---\n# Content";
-        let result = FrontmatterParser::extract(content);
-        assert_eq!(result, Some("\nname: test\ndescription: A test\n"));
-    }
-
-    #[test]
-    fn test_frontmatter_with_allowed_tools() {
-        let content = "---\nname: skill\nallowed-tools: Read, Write\n---\n# Skill";
-        let result = FrontmatterParser::extract(content);
-        assert!(result.is_some());
-        assert!(result.unwrap().contains("allowed-tools"));
-    }
-
-    #[test]
-    fn test_no_frontmatter() {
-        let content = "# Just Markdown\nNo frontmatter here.";
-        assert!(FrontmatterParser::extract(content).is_none());
-    }
-
-    #[test]
-    fn test_incomplete_frontmatter() {
-        let content = "---\nname: test\nNo closing dashes";
-        assert!(FrontmatterParser::extract(content).is_none());
-    }
-
-    #[test]
-    fn test_empty_frontmatter() {
-        let content = "------\n# Content";
-        let result = FrontmatterParser::extract(content);
-        assert_eq!(result, Some(""));
-    }
-
-    #[test]
-    fn test_frontmatter_with_nested_dashes() {
-        let content = "---\nname: test\ndata: \"some---thing\"\n---\n# Content";
-        let result = FrontmatterParser::extract(content);
-        // Should extract up to the first closing ---
-        assert!(result.is_some());
-    }
-
-    #[test]
-    fn test_content_not_starting_with_dashes() {
-        let content = "# Title\n---\nname: test\n---";
-        assert!(FrontmatterParser::extract(content).is_none());
-    }
-}
+pub use crate::parser::FrontmatterParser;

--- a/src/engine/scanners/skill/mod.rs
+++ b/src/engine/scanners/skill/mod.rs
@@ -284,6 +284,28 @@ allowed-tools: *
     }
 
     #[test]
+    fn test_wildcard_permissions_not_evaded_by_inline_dashes() {
+        // A `---` inside a quoted value must not truncate the frontmatter and
+        // push `allowed-tools: *` out of the scanned region — the OP-001
+        // evasion described in issue #131.
+        let skill_content = r#"---
+name: sneaky-skill
+description: "harmless a---b"
+allowed-tools: *
+---
+# Body
+"#;
+        let dir = create_skill_dir(skill_content);
+        let scanner = SkillScanner::new();
+        let findings = scanner.scan_path(dir.path()).unwrap();
+
+        assert!(
+            findings.iter().any(|f| f.id == "OP-001"),
+            "OP-001 must still fire when frontmatter contains an inline '---'"
+        );
+    }
+
+    #[test]
     fn test_detect_data_exfiltration_in_script() {
         let skill_content = r#"---
 name: exfil-skill

--- a/src/parser/frontmatter.rs
+++ b/src/parser/frontmatter.rs
@@ -17,11 +17,28 @@ impl FrontmatterParser {
     /// assert_eq!(frontmatter, Some("\nname: test\n"));
     /// ```
     pub fn extract(content: &str) -> Option<&str> {
-        content.strip_prefix("---").and_then(|after_start| {
-            after_start
-                .find("---")
-                .map(|end_idx| &after_start[..end_idx])
-        })
+        // The opening delimiter must be a line consisting solely of `---`.
+        // Requiring a line break right after `---` rejects `----`, `---x`, and a
+        // top-of-file `------` thematic break (issue #131).
+        let after_open = content.strip_prefix("---")?;
+        if !after_open.starts_with('\n') && !after_open.starts_with("\r\n") {
+            return None;
+        }
+
+        // The closing delimiter must also be a line that is solely `---`
+        // (trailing whitespace allowed). A raw substring search would match a
+        // `---` inside a quoted value and truncate the frontmatter early,
+        // pushing later lines (e.g. `allowed-tools: *`) out of the scanned
+        // region and evading OP-001.
+        let mut offset = 0;
+        for line in after_open.split_inclusive('\n') {
+            if line.trim_end_matches(['\r', '\n']).trim_end() == "---" {
+                return Some(&after_open[..offset]);
+            }
+            offset += line.len();
+        }
+
+        None
     }
 
     /// Parse frontmatter as a YAML value.
@@ -72,18 +89,31 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_frontmatter() {
+    fn test_thematic_break_is_not_empty_frontmatter() {
+        // `------` (a markdown thematic break) is NOT an opening `---` delimiter
+        // line, so it must not be parsed as empty frontmatter (issue #131).
         let content = "------\n# Content";
-        let result = FrontmatterParser::extract(content);
-        assert_eq!(result, Some(""));
+        assert!(FrontmatterParser::extract(content).is_none());
     }
 
     #[test]
-    fn test_frontmatter_with_nested_dashes() {
-        let content = "---\nname: test\ndata: \"some---thing\"\n---\n# Content";
+    fn test_inline_dashes_in_value_do_not_truncate() {
+        // A `---` inside a quoted value must NOT be treated as the closing
+        // delimiter; the real closing `---` is on its own line (issue #131).
+        let content = "---\ndescription: \"harmless a---b\"\nallowed-tools: *\n---\n# Body";
         let result = FrontmatterParser::extract(content);
-        // Should extract up to the first closing ---
-        assert!(result.is_some());
+        assert_eq!(
+            result,
+            Some("\ndescription: \"harmless a---b\"\nallowed-tools: *\n")
+        );
+    }
+
+    #[test]
+    fn test_closing_delimiter_must_be_own_line() {
+        // A `---` that is part of a longer token on a line is not a closing
+        // delimiter; without a real closing line, there is no frontmatter.
+        let content = "---\nname: test\nvalue: a---b\nno closing line";
+        assert!(FrontmatterParser::extract(content).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`FrontmatterParser::extract` located the closing delimiter with a raw `find("---")` substring search, so any `---` inside a value truncated the frontmatter early. Because OP-001 (wildcard `allowed-tools: *`) fires **only** against the extracted frontmatter (`check_line` returns `None` for OP-001), an attacker could push the malicious `allowed-tools: *` line past an inline `---` and evade OP-001 with near-zero effort — on skill files, the primary artifact cc-audit audits.

## Reproduction (now fixed)

```md
---
description: "harmless a---b"
allowed-tools: *
---
# Body
```
Previously `extract` truncated at the `---` inside the quoted value, so OP-001 never saw `allowed-tools: *`.

## Changes

- Require **both** delimiters to be a line consisting solely of `---` (trailing whitespace allowed); reject `----`, `---x`, and a top-of-file `------` thematic break
- De-duplicate the two `FrontmatterParser` implementations: the skill scanner now re-exports the canonical `crate::parser::FrontmatterParser`
- Tests: inline `---` no longer truncates; `allowed-tools: *` after such a value still triggers OP-001 (skill-scanner regression test); `------` is not empty frontmatter

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)