### PR TITLE
fix(engine): cap per-file read size to prevent OOM DoS

### DIFF
--- a/src/engine/scanner.rs
+++ b/src/engine/scanner.rs
@@ -12,6 +12,95 @@ use std::fs;
 use std::path::Path;
 use tracing::{debug, trace};
 
+/// Maximum size, in bytes, of a single file the scanner will read into memory.
+///
+/// cc-audit inspects untrusted third-party artifacts, so an attacker fully
+/// controls file sizes. Reading an arbitrarily large file unconditionally lets a
+/// single multi-GB file exhaust memory and OOM-kill the scan (a DoS that can
+/// fail the security gate open). Files above this cap are refused *before* any
+/// allocation. 10 MiB is far above any legitimate Claude Code artifact
+/// (skills, hooks, MCP configs, lockfiles) while bounding worst-case memory.
+///
+/// See issue #143 (CWE-400 Uncontrolled Resource Consumption, CWE-770
+/// Allocation of Resources Without Limits).
+pub const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
+
+/// Reads a file into a `String`, refusing to allocate for files larger than
+/// `limit` bytes.
+///
+/// The size is checked via `fs::metadata` **before** the file is read, so an
+/// oversized file never drives a large allocation. Returns
+/// [`AuditError::FileTooLarge`] for oversized files and [`AuditError::ReadError`]
+/// for genuine I/O errors. Bytes are lossy-decoded (invalid UTF-8 → replacement
+/// char) so a partially-binary file is still scanned rather than skipped (issue
+/// #129).
+pub fn read_to_string_capped_with_limit(path: &Path, limit: u64) -> Result<String> {
+    let metadata = fs::metadata(path).map_err(|e| AuditError::ReadError {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+
+    let size = metadata.len();
+    if size > limit {
+        return Err(AuditError::FileTooLarge {
+            path: path.display().to_string(),
+            size,
+            limit,
+        });
+    }
+
+    let bytes = fs::read(path).map_err(|e| AuditError::ReadError {
+        path: path.display().to_string(),
+        source: e,
+    })?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Reads a file into a `String`, refusing files larger than [`MAX_FILE_SIZE`].
+///
+/// Convenience wrapper over [`read_to_string_capped_with_limit`] for the many
+/// scan readers that use the default cap.
+pub fn read_to_string_capped(path: &Path) -> Result<String> {
+    read_to_string_capped_with_limit(path, MAX_FILE_SIZE)
+}
+
+/// Builds a fail-loud diagnostic finding for a file skipped because it exceeded
+/// the size cap.
+///
+/// Emitting a finding (rather than silently dropping the file) prevents an
+/// oversized file from faking a clean scan or hiding content above the cap —
+/// the fail-loud coverage contract from issue #136. Modeled as a low-severity
+/// supply-chain concern: an oversized untrusted artifact is suspicious in its
+/// own right.
+pub fn oversize_file_finding(file: &str, size: u64, limit: u64) -> Finding {
+    Finding {
+        id: "SC-SIZE-001".to_string(),
+        severity: crate::rules::Severity::Low,
+        category: crate::rules::Category::SupplyChain,
+        confidence: crate::rules::Confidence::Certain,
+        name: "Oversized file skipped".to_string(),
+        location: crate::rules::Location {
+            file: file.to_string(),
+            line: 0,
+            column: None,
+        },
+        code: String::new(),
+        message: format!(
+            "File is {size} bytes, exceeding the {limit}-byte scan limit; it was \
+             not scanned. An oversized untrusted artifact can exhaust memory or \
+             hide content above the cap."
+        ),
+        recommendation: "Review this file manually. If it is legitimate, raise the \
+             configured size limit; otherwise treat the oversized artifact as suspicious."
+            .to_string(),
+        fix_hint: None,
+        cwe_ids: vec!["CWE-400".to_string(), "CWE-770".to_string()],
+        rule_severity: None,
+        client: None,
+        context: None,
+    }
+}
+
 /// Core trait for all security scanners.
 ///
 /// Scanners implement this trait to provide file and directory scanning capabilities.
@@ -86,6 +175,7 @@ pub struct ScannerConfig {
     strict_secrets: bool,
     recursive: bool,
     progress_callback: Option<ProgressCallback>,
+    max_file_size: u64,
 }
 
 impl ScannerConfig {
@@ -98,7 +188,21 @@ impl ScannerConfig {
             strict_secrets: false,
             recursive: true,
             progress_callback: None,
+            max_file_size: MAX_FILE_SIZE,
         }
+    }
+
+    /// Overrides the maximum size (in bytes) of a file that will be read into
+    /// memory. Files above the cap are refused before allocation (see
+    /// [`MAX_FILE_SIZE`]).
+    pub fn with_max_file_size(mut self, max_file_size: u64) -> Self {
+        self.max_file_size = max_file_size;
+        self
+    }
+
+    /// Returns the configured maximum file size in bytes.
+    pub fn max_file_size(&self) -> u64 {
+        self.max_file_size
     }
 
     /// Enables or disables recursive scanning.
@@ -175,21 +279,18 @@ impl ScannerConfig {
 
     /// Reads a file and returns its content as a string.
     ///
-    /// Reads raw bytes and lossy-decodes them (invalid UTF-8 → replacement
-    /// char) so a single non-UTF-8 byte cannot silently neutralize the scan for
-    /// an entire file (issue #129). Only genuine IO errors (missing file,
-    /// permission denied) are propagated; a legacy-encoded or partially-binary
-    /// file is still scanned rather than failing open.
+    /// Refuses files larger than the configured cap ([`ScannerConfig::max_file_size`])
+    /// before allocating, so an oversized untrusted artifact cannot OOM-kill the
+    /// scan (issue #143). Otherwise reads raw bytes and lossy-decodes them
+    /// (invalid UTF-8 → replacement char) so a single non-UTF-8 byte cannot
+    /// silently neutralize the scan for an entire file (issue #129). Only genuine
+    /// IO errors and the size cap are propagated; a legacy-encoded or
+    /// partially-binary file is still scanned rather than failing open.
     pub fn read_file(&self, path: &Path) -> Result<String> {
         trace!(path = %path.display(), "Reading file");
-        let bytes = fs::read(path).map_err(|e| {
+        read_to_string_capped_with_limit(path, self.max_file_size).inspect_err(|e| {
             debug!(path = %path.display(), error = %e, "Failed to read file");
-            AuditError::ReadError {
-                path: path.display().to_string(),
-                source: e,
-            }
-        })?;
-        Ok(String::from_utf8_lossy(&bytes).into_owned())
+        })
     }
 
     /// Checks the content against all rules and returns findings.
@@ -301,6 +402,54 @@ mod tests {
         let config = ScannerConfig::new();
         let result = config.read_file(Path::new("/nonexistent/file.txt"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_to_string_capped_rejects_oversized() {
+        // A file larger than the (tiny) limit must be refused with FileTooLarge,
+        // never read into memory (issue #143 — OOM / DoS prevention).
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("big.txt");
+        fs::write(&file_path, vec![b'a'; 100]).unwrap();
+
+        let err = read_to_string_capped_with_limit(&file_path, 10).unwrap_err();
+        assert!(
+            matches!(err, AuditError::FileTooLarge { size, limit, .. } if size == 100 && limit == 10),
+            "oversized file must yield FileTooLarge, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_read_to_string_capped_allows_within_limit() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("ok.txt");
+        fs::write(&file_path, "hello").unwrap();
+
+        let content = read_to_string_capped_with_limit(&file_path, 1024).unwrap();
+        assert_eq!(content, "hello");
+    }
+
+    #[test]
+    fn test_read_file_respects_configured_size_cap() {
+        let dir = TempDir::new().unwrap();
+        let file_path = dir.path().join("payload.md");
+        fs::write(&file_path, vec![b'x'; 5000]).unwrap();
+
+        // Default cap reads it fine; a small configured cap refuses it.
+        assert!(ScannerConfig::new().read_file(&file_path).is_ok());
+        let err = ScannerConfig::new()
+            .with_max_file_size(1000)
+            .read_file(&file_path)
+            .unwrap_err();
+        assert!(matches!(err, AuditError::FileTooLarge { .. }));
+    }
+
+    #[test]
+    fn test_oversize_file_finding_is_fail_loud() {
+        let finding = oversize_file_finding("evil/big.md", 50_000_000, MAX_FILE_SIZE);
+        assert_eq!(finding.id, "SC-SIZE-001");
+        assert_eq!(finding.category, crate::rules::Category::SupplyChain);
+        assert_eq!(finding.location.file, "evil/big.md");
     }
 
     #[test]

--- a/src/engine/scanners/macros.rs
+++ b/src/engine/scanners/macros.rs
@@ -61,6 +61,13 @@ macro_rules! impl_scanner_builder {
                 self
             }
 
+            /// Overrides the maximum size (in bytes) of a file that will be read
+            /// into memory. Files above the cap are refused before allocation.
+            pub fn with_max_file_size(mut self, max_file_size: u64) -> Self {
+                self.config = self.config.with_max_file_size(max_file_size);
+                self
+            }
+
             /// Sets a progress callback that will be called for each scanned file.
             pub fn with_progress_callback(
                 mut self,

--- a/src/engine/scanners/plugin.rs
+++ b/src/engine/scanners/plugin.rs
@@ -2,7 +2,6 @@ use crate::engine::scanner::{Scanner, ScannerConfig};
 use crate::error::{AuditError, Result};
 use crate::rules::Finding;
 use serde::Deserialize;
-use std::fs;
 use std::path::Path;
 
 /// Plugin definition structure for marketplace.json
@@ -206,10 +205,8 @@ impl PluginScanner {
 
 impl Scanner for PluginScanner {
     fn scan_file(&self, path: &Path) -> Result<Vec<Finding>> {
-        let content = fs::read_to_string(path).map_err(|e| AuditError::ReadError {
-            path: path.display().to_string(),
-            source: e,
-        })?;
+        // Cap the read so an oversized artifact cannot OOM the scan (#143).
+        let content = crate::engine::scanner::read_to_string_capped(path)?;
         self.scan_content(&content, &path.display().to_string())
     }
 
@@ -241,6 +238,7 @@ impl Scanner for PluginScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use tempfile::TempDir;
 
     #[test]

--- a/src/engine/scanners/skill/mod.rs
+++ b/src/engine/scanners/skill/mod.rs
@@ -88,8 +88,18 @@ impl Scanner for SkillScanner {
     }
 
     fn scan_file(&self, path: &Path) -> Result<Vec<Finding>> {
-        let content = self.config.read_file(path)?;
         let path_str = path.display().to_string();
+        let content = match self.config.read_file(path) {
+            Ok(content) => content,
+            // Fail loud: an oversized file is skipped but surfaced as a finding so
+            // it cannot fake a clean scan or hide content above the cap (#143/#136).
+            Err(crate::error::AuditError::FileTooLarge { size, limit, .. }) => {
+                return Ok(vec![crate::engine::scanner::oversize_file_finding(
+                    &path_str, size, limit,
+                )]);
+            }
+            Err(e) => return Err(e),
+        };
         let findings = self.config.check_content(&content, &path_str);
 
         // Note: Progress reporting is handled by the caller (scan_directory or scan_path)
@@ -519,6 +529,27 @@ cat ~/.ssh/id_rsa
         assert!(
             findings.iter().any(|f| f.id == "EX-015"),
             "reverse shell in an extension-less shebang script must be detected"
+        );
+    }
+
+    #[test]
+    fn test_scan_oversized_file_is_skipped_with_diagnostic() {
+        // Regression for #143: an oversized file must not OOM the scan; it is
+        // skipped and surfaced as a fail-loud SC-SIZE-001 diagnostic instead of
+        // silently disappearing.
+        let dir = TempDir::new().unwrap();
+        let skill_md = dir.path().join("SKILL.md");
+        fs::write(&skill_md, "---\nname: test\n---\n# Test").unwrap();
+
+        let big = dir.path().join("big.md");
+        fs::write(&big, vec![b'a'; 4096]).unwrap();
+
+        // Tiny cap so we don't need a real multi-MB file in the test.
+        let scanner = SkillScanner::new().with_max_file_size(1024);
+        let findings = scanner.scan_path(dir.path()).unwrap();
+        assert!(
+            findings.iter().any(|f| f.id == "SC-SIZE-001"),
+            "oversized file must yield a fail-loud diagnostic finding"
         );
     }
 

--- a/src/engine/scanners/subagent.rs
+++ b/src/engine/scanners/subagent.rs
@@ -1,9 +1,8 @@
 use super::walker::{DirectoryWalker, WalkConfig};
 use crate::engine::scanner::{Scanner, ScannerConfig};
-use crate::error::{AuditError, Result};
+use crate::error::Result;
 use crate::rules::Finding;
 use rayon::prelude::*;
-use std::fs;
 use std::path::{Path, PathBuf};
 use tracing::{debug, warn};
 
@@ -68,10 +67,8 @@ impl SubagentScanner {
 
 impl Scanner for SubagentScanner {
     fn scan_file(&self, path: &Path) -> Result<Vec<Finding>> {
-        let content = fs::read_to_string(path).map_err(|e| AuditError::ReadError {
-            path: path.display().to_string(),
-            source: e,
-        })?;
+        // Cap the read so an oversized artifact cannot OOM the scan (#143).
+        let content = crate::engine::scanner::read_to_string_capped(path)?;
         self.scan_content(&content, &path.display().to_string())
     }
 
@@ -114,6 +111,7 @@ impl Scanner for SubagentScanner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use tempfile::TempDir;
 
     #[test]

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -30,6 +30,9 @@ pub enum AuditError {
         source: std::io::Error,
     },
 
+    #[error("File too large to scan: {path} ({size} bytes exceeds limit of {limit} bytes)")]
+    FileTooLarge { path: String, size: u64, limit: u64 },
+
     #[error("Failed to parse YAML frontmatter: {path}")]
     YamlParseError {
         path: String,

--- a/src/run/cve.rs
+++ b/src/run/cve.rs
@@ -1,7 +1,6 @@
 //! CVE database scanning for dependency vulnerabilities.
 
 use crate::{CveDatabase, DirectoryWalker, Finding, IgnoreFilter, WalkConfig};
-use std::fs;
 use std::path::Path;
 use tracing::{debug, info};
 
@@ -29,7 +28,8 @@ pub fn scan_path_with_cve_db(
         if !ignore_filter.is_ignored(path)
             && let Some(name) = path.file_name().and_then(|n| n.to_str())
             && CVE_RELEVANT_FILES.contains(&name)
-            && let Ok(content) = fs::read_to_string(path)
+            // Cap the read so an oversized lockfile cannot OOM the scan (#143).
+            && let Ok(content) = crate::engine::scanner::read_to_string_capped(path)
         {
             debug!(path = %path.display(), "Checking file for CVE vulnerabilities");
             findings.extend(check_content_for_cves(&content, path, db));
@@ -41,7 +41,7 @@ pub fn scan_path_with_cve_db(
             if !ignore_filter.is_ignored(&file_path)
                 && let Some(name) = file_path.file_name().and_then(|n| n.to_str())
                 && CVE_RELEVANT_FILES.contains(&name)
-                && let Ok(content) = fs::read_to_string(&file_path)
+                && let Ok(content) = crate::engine::scanner::read_to_string_capped(&file_path)
             {
                 findings.extend(check_content_for_cves(&content, &file_path, db));
             }
@@ -181,6 +181,7 @@ fn check_content_for_cves(content: &str, path: &Path, db: &CveDatabase) -> Vec<F
 mod tests {
     use super::*;
     use crate::config::IgnoreConfig;
+    use std::fs;
     use std::io::Write;
     use tempfile::TempDir;
 

--- a/src/run/malware.rs
+++ b/src/run/malware.rs
@@ -1,7 +1,6 @@
 //! Malware database scanning.
 
 use crate::{DirectoryWalker, Finding, IgnoreFilter, MalwareDatabase, WalkConfig};
-use std::fs;
 use std::path::Path;
 use tracing::debug;
 
@@ -22,7 +21,8 @@ pub fn scan_path_with_malware_db(
         // Skip ignored and config files
         if !ignore_filter.is_ignored(path)
             && !is_config_file(path)
-            && let Ok(content) = fs::read_to_string(path)
+            // Cap the read so an oversized artifact cannot OOM the scan (#143).
+            && let Ok(content) = crate::engine::scanner::read_to_string_capped(path)
         {
             debug!(path = %path.display(), "Scanning file for malware signatures");
             findings.extend(db.scan_content(&content, &path.display().to_string()));
@@ -35,7 +35,7 @@ pub fn scan_path_with_malware_db(
             if !ignore_filter.is_ignored(&file_path)
                 && !is_config_file(&file_path)
                 && is_text_file(&file_path)
-                && let Ok(content) = fs::read_to_string(&file_path)
+                && let Ok(content) = crate::engine::scanner::read_to_string_capped(&file_path)
             {
                 findings.extend(db.scan_content(&content, &file_path.display().to_string()));
             }
@@ -49,6 +49,7 @@ pub fn scan_path_with_malware_db(
 mod tests {
     use super::*;
     use crate::config::IgnoreConfig;
+    use std::fs;
     use std::io::Write;
     use tempfile::TempDir;
 

--- a/src/run/scanner.rs
+++ b/src/run/scanner.rs
@@ -8,7 +8,6 @@ use crate::{
     WalkConfig,
 };
 use chrono::Utc;
-use std::fs;
 use std::io::IsTerminal;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -443,12 +442,13 @@ pub(crate) fn run_deep_scan(path: &Path, ignore_filter: &IgnoreFilter) -> Vec<Fi
 
     if path.is_file() {
         // Lossy-decode so a non-UTF-8 byte cannot silently skip the deep scan
-        // for the whole file (issue #129); only IO errors drop the file.
+        // for the whole file (issue #129); only IO errors and the size cap drop
+        // the file. The read is capped so an oversized artifact cannot OOM the
+        // deep scan (issue #143).
         if !ignore_filter.is_ignored(path)
             && is_text_file(path)
-            && let Ok(bytes) = fs::read(path)
+            && let Ok(content) = crate::engine::scanner::read_to_string_capped(path)
         {
-            let content = String::from_utf8_lossy(&bytes);
             debug!(path = %path.display(), "Running deep scan on file");
             findings.extend(deobfuscator.deep_scan(&content, &path.display().to_string()));
         }
@@ -458,9 +458,8 @@ pub(crate) fn run_deep_scan(path: &Path, ignore_filter: &IgnoreFilter) -> Vec<Fi
         for file_path in walker.walk_single(path) {
             if !ignore_filter.is_ignored(&file_path)
                 && is_text_file(&file_path)
-                && let Ok(bytes) = fs::read(&file_path)
+                && let Ok(content) = crate::engine::scanner::read_to_string_capped(&file_path)
             {
-                let content = String::from_utf8_lossy(&bytes);
                 findings.extend(deobfuscator.deep_scan(&content, &file_path.display().to_string()));
             }
         }
@@ -505,6 +504,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::io::Write;
     use tempfile::TempDir;
 


### PR DESCRIPTION
## Summary

Closes #143.

cc-audit inspects **untrusted third-party artifacts before install**, so an attacker fully controls file sizes. Every reader called `fs::read` / `fs::read_to_string` unconditionally — `read_to_string` even pre-reserves capacity from the file's metadata length — so a single multi-GB file could exhaust memory and OOM-kill the scan. A pre-install security gate that the very input it inspects can crash is a **DoS / gate-bypass** (CWE-400, CWE-770).

## Change

- **`MAX_FILE_SIZE` = 10 MiB** + `read_to_string_capped[_with_limit]` (in `engine/scanner.rs`): checks `fs::metadata(path).len()` **before** reading, so an oversized file never drives a large allocation. Bytes are still lossy-decoded (keeps the #129 non-UTF-8 fix).
- Route **every reader** through the cap: central `ScannerConfig::read_file`, plus the standalone `malware`, `cve`, deep-scan (`run/scanner.rs`), `subagent`, and `plugin` readers.
- **Configurable**: `ScannerConfig::with_max_file_size` + a `with_max_file_size` passthrough on all scanner builders.
- **Fail loud** on the default skill path (#136): an oversized file is skipped but surfaced as a low-severity `SC-SIZE-001` diagnostic (CWE-400/770) instead of silently disappearing — so it can't fake a clean scan or hide content above the cap.

## Tests (TDD)

- `read_to_string_capped_with_limit`: 100-byte file over a 10-byte limit → `FileTooLarge`; within limit → content.
- `ScannerConfig::read_file` honors a configured cap (default reads; tiny cap refuses).
- `oversize_file_finding` → `SC-SIZE-001` / SupplyChain.
- Skill e2e: oversized file in a scanned dir yields the `SC-SIZE-001` diagnostic (no OOM).
- Full suite green (1753 lib + integration).

## Scope note

Default cap is a generous hardcoded 10 MiB (far above any real skill/hook/MCP/lockfile). Wiring the cap to a `.cc-audit.yaml` field and emitting the diagnostic on the non-skill readers (currently bounded but skipped quietly) are natural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)