### PR TITLE
build(hooks): block direct commits and pushes to main

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,6 +1,18 @@
 #!/bin/sh
 set -e
 
+# Reject commits made directly on 'main'. Feature work belongs on a branch;
+# main is only ever advanced by a reviewed, merged pull request. Checked first
+# so it fails fast, before the expensive fmt/clippy run.
+# Escape hatch (emergencies only): ALLOW_MAIN_COMMIT=1 git commit ...
+branch=$(git symbolic-ref --short -q HEAD || echo "")
+if [ "$branch" = "main" ] && [ "${ALLOW_MAIN_COMMIT:-0}" != "1" ]; then
+    echo "ERROR: Direct commits to 'main' are not allowed." >&2
+    echo "  Create a feature branch:  git switch -c fix/your-change" >&2
+    echo "  Override (emergency):     ALLOW_MAIN_COMMIT=1 git commit ..." >&2
+    exit 1
+fi
+
 echo "Running pre-commit checks..."
 
 # Format check (same as CI)

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,6 +1,20 @@
 #!/bin/sh
 set -e
 
+# Reject pushes that update the remote 'main' branch. main advances only through
+# a merged pull request, never a direct push. git feeds one line per ref update
+# on stdin: "<local ref> <local oid> <remote ref> <remote oid>". Checked first so
+# it fails fast, before the expensive test run.
+# Escape hatch (emergencies only): ALLOW_MAIN_PUSH=1 git push ...
+while read -r _local_ref _local_oid remote_ref _remote_oid; do
+    if [ "$remote_ref" = "refs/heads/main" ] && [ "${ALLOW_MAIN_PUSH:-0}" != "1" ]; then
+        echo "ERROR: Direct pushes to 'main' are not allowed." >&2
+        echo "  Open a pull request instead." >&2
+        echo "  Override (emergency): ALLOW_MAIN_PUSH=1 git push ..." >&2
+        exit 1
+    fi
+done
+
 echo "Running pre-push checks..."
 
 # Run tests (same as CI)

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -61,8 +61,8 @@ fn setup_hooks() -> Result<()> {
     println!("Git hooks configured successfully!");
     println!();
     println!("Hooks enabled:");
-    println!("  - pre-commit: cargo fmt --check, cargo clippy");
-    println!("  - pre-push: cargo test");
+    println!("  - pre-commit: block direct commits to main, cargo fmt --check, cargo clippy");
+    println!("  - pre-push: block direct pushes to main, cargo test");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds a guard to the two shared git hooks (`core.hooksPath=.githooks`) so **main is only ever advanced through a reviewed, merged pull request** — direct commits and pushes to main are rejected locally.

- **pre-commit**: rejects when `HEAD` is on `main`, checked *before* fmt/clippy (fast-fail).
- **pre-push**: rejects any ref update targeting `refs/heads/main`, checked *before* the test run (fast-fail).
- `xtask setup-hooks` output updated to list the new guards.

## Escape hatch

Each guard honors a documented emergency override that **still runs the normal checks** (unlike `--no-verify`):

```sh
ALLOW_MAIN_COMMIT=1 git commit ...
ALLOW_MAIN_PUSH=1   git push ...
```

## Honest limitation

Client-side hooks are a **safety net, not a security boundary** — `--no-verify` still bypasses them entirely. For a hard control, enable branch protection on `main` at the remote (GitHub → Settings → Branches). This PR is the local convenience layer that catches accidental direct-to-main operations.

## Validation

- pre-commit/pre-push guard paths exercised for: on-main (blocked), feature branch (allowed), override (allowed).
- Real hooks confirmed to fast-fail on main *before* the expensive checks.
- Dogfooded: this PR's own commit ran pre-commit green, and its push ran the full test suite green via pre-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)