### PR TITLE
fix(rules): PE-003 chmod-777 detection tolerates flags and mode prefixes (#217)

### DIFF
--- a/src/rules/builtin/privilege.rs
+++ b/src/rules/builtin/privilege.rs
@@ -83,10 +83,11 @@ fn pe_003() -> Rule {
         category: Category::PrivilegeEscalation,
         confidence: Confidence::Certain,
         patterns: vec![
-            Regex::new(r"chmod\s+777\b").expect("PE-003: invalid regex"),
-            Regex::new(r"chmod\s+[0-7]?777\b").expect("PE-003: invalid regex"),
-            Regex::new(r"chmod\s+-R\s+777\b").expect("PE-003: invalid regex"),
-            Regex::new(r"chmod\s+a\+rwx\b").expect("PE-003: invalid regex"),
+            // Tolerate any leading flags (`-R`, `-Rf`, `--recursive`) and mode
+            // prefixes (`0777`, `00777`, setuid/sticky like `4777`). See #217.
+            Regex::new(r"chmod\s+(-{1,2}[a-zA-Z]+\s+)*[0-7]*777\b").expect("PE-003: invalid regex"),
+            // Symbolic world-writable, with or without a recursive flag.
+            Regex::new(r"chmod\s+(-{1,2}[a-zA-Z]+\s+)*a\+rwx\b").expect("PE-003: invalid regex"),
         ],
         exclusions: vec![],
         message: "Insecure permissions: chmod 777 makes files world-writable",
@@ -392,8 +393,16 @@ mod tests {
             ("chmod 777 /tmp/file", true),
             ("chmod -R 777 /var/www", true),
             ("chmod a+rwx script.sh", true),
+            // Regression (#217): flag/leading-zero/symbolic variants must be caught.
+            ("chmod -Rf 777 /var/www", true),
+            ("chmod -R 0777 /var/www", true),
+            ("chmod 00777 file", true),
+            ("chmod --recursive 777 /srv", true),
+            ("chmod -R a+rwx /srv", true),
+            ("chmod 4777 /usr/bin/x", true), // setuid + world-writable
             ("chmod 755 /tmp/file", false),
             ("chmod 644 config.txt", false),
+            ("chmod +x script.sh", false),
         ];
 
         for (input, should_match) in test_cases {


### PR DESCRIPTION
## Summary

PE-003 (world-writable `chmod 777`, Critical) hardcoded `-R` and a single optional leading digit. Everyday variants slipped through: `chmod -Rf 777`, `chmod -R 0777`, `chmod 00777`, `chmod --recursive 777`, `chmod -R a+rwx`.

## Fix

Replace the four brittle patterns with two flag-tolerant ones:

```rust
r"chmod\s+(-{1,2}[a-zA-Z]+\s+)*[0-7]*777\b"
r"chmod\s+(-{1,2}[a-zA-Z]+\s+)*a\+rwx\b"
```

`[0-7]*` mirrors the form PE-006 already uses. `chmod +x` (no `-` flag, no `777`) is still not flagged.

## Testing

Regression cases added to `test_pe_003_detects_chmod_777`: `-Rf 777`, `-R 0777`, `00777`, `--recursive 777`, `-R a+rwx`, `4777` now detected; `755`/`644`/`+x` still not.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL