### PR TITLE
fix(scanners): detect Dockerfile.<suffix> variants (#226)

### DIFF
--- a/src/engine/scanners/dockerfile.rs
+++ b/src/engine/scanners/dockerfile.rs
@@ -27,6 +27,8 @@ impl DockerScanner {
         match file_name {
             Some(name) => {
                 name == "dockerfile"
+                    // `Dockerfile.<suffix>` variants: .staging, .base, .ci, … (#226)
+                    || name.starts_with("dockerfile.")
                     || name.ends_with(".dockerfile")
                     || name == "docker-compose.yml"
                     || name == "docker-compose.yaml"
@@ -253,6 +255,29 @@ RUN npm install
     }
 
     #[test]
+    fn test_scan_dockerfile_suffix_variant() {
+        // Regression (#226): `Dockerfile.<env>` variants must be scanned.
+        let dir = TempDir::new().unwrap();
+        create_dockerfile(
+            &dir,
+            "Dockerfile.staging",
+            r#"
+FROM node:18
+USER root
+RUN curl -fsSL https://get.docker.com | bash
+"#,
+        );
+
+        let scanner = DockerScanner::new();
+        let findings = scanner.scan_path(dir.path()).unwrap();
+
+        assert!(
+            findings.iter().any(|f| f.id == "DK-002"),
+            "Should detect USER root in Dockerfile.staging"
+        );
+    }
+
+    #[test]
     fn test_scan_empty_directory() {
         let dir = TempDir::new().unwrap();
         let scanner = DockerScanner::new();
@@ -315,8 +340,16 @@ RUN docker run --privileged nginx
         )));
         assert!(DockerScanner::is_dockerfile(Path::new("compose.yml")));
         assert!(DockerScanner::is_dockerfile(Path::new("compose.yaml")));
+        // Regression (#226): Dockerfile.<suffix> variants.
+        assert!(DockerScanner::is_dockerfile(Path::new(
+            "Dockerfile.staging"
+        )));
+        assert!(DockerScanner::is_dockerfile(Path::new("Dockerfile.base")));
+        assert!(DockerScanner::is_dockerfile(Path::new("Dockerfile.ci")));
+        assert!(DockerScanner::is_dockerfile(Path::new("dockerfile.prod")));
         assert!(!DockerScanner::is_dockerfile(Path::new("README.md")));
         assert!(!DockerScanner::is_dockerfile(Path::new("script.sh")));
+        assert!(!DockerScanner::is_dockerfile(Path::new("mydockerfile.txt")));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`DockerScanner` recognized only `Dockerfile`, `*.dockerfile`, and a hardcoded list whose only suffix variants were `.dev`/`.prod`. `Dockerfile.staging` / `.base` / `.ci` (common multi-stage / CI naming) lowercase to `dockerfile.<suffix>`, which matched neither `== "dockerfile"` nor `.ends_with(".dockerfile")`, so DK-001/002/003 silently skipped them.

## Fix

`is_dockerfile` (used by the recursive discovery pass) now also matches any filename whose lowercased form starts with `dockerfile.`. `mydockerfile.txt` remains excluded.

Note: the `WalkDir::max_depth(3)` cap is intentionally retained as a scan-performance tradeoff and is out of scope here.

## Testing

- `test_is_dockerfile` extended: `Dockerfile.staging/.base/.ci`, `dockerfile.prod` accepted; `mydockerfile.txt` rejected.
- New `test_scan_dockerfile_suffix_variant`: a `Dockerfile.staging` with `USER root` is now detected end-to-end via `scan_directory` (DK-002).

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL