### PR TITLE
fix(rules): DK-002 detects root via uid:gid form (USER 0:0 / root:root) (#235)

### DIFF
--- a/src/rules/builtin/docker.rs
+++ b/src/rules/builtin/docker.rs
@@ -55,10 +55,9 @@ fn dk_002() -> Rule {
         category: Category::PrivilegeEscalation,
         confidence: Confidence::Firm,
         patterns: vec![
-            // USER root (multiline mode with (?m))
-            Regex::new(r"(?im)^USER\s+root\s*$").expect("DK-002: invalid regex"),
-            // USER 0
-            Regex::new(r"(?m)^USER\s+0\s*$").expect("DK-002: invalid regex"),
+            // USER root / USER 0, optionally with a `:<gid>` suffix
+            // (`USER 0:0`, `USER root:root`). See #235.
+            Regex::new(r"(?im)^USER\s+(root|0)(:\S+)?\s*$").expect("DK-002: invalid regex"),
             // user: root in compose
             Regex::new(r#"user:\s*["']?root["']?"#).expect("DK-002: invalid regex"),
             Regex::new(r#"user:\s*["']?0["']?"#).expect("DK-002: invalid regex"),
@@ -302,12 +301,16 @@ mod tests {
             // Should detect
             ("USER root", true),
             ("USER 0", true),
+            // Regression (#235): uid:gid form.
+            ("USER 0:0", true),
+            ("USER root:root", true),
             ("user: root", true),
             ("user: \"root\"", true),
             ("user: 0", true),
             // Should not detect
             ("USER nobody", false),
             ("USER 1000", false),
+            ("USER 1000:1000", false),
             ("user: app", false),
             ("# USER root", false), // comment
         ];


### PR DESCRIPTION
## Summary

DK-002 (container runs as root) matched only bare `root`/`0` in the Dockerfile branch, so `USER 0:0` and `USER root:root` (the `USER <uid>[:<gid>]` form) evaded it. The Compose branch already handled `user: "0:0"`, confirming the omission.

## Fix

Allow an optional `:<gid>` suffix and collapse the two Dockerfile patterns into one: `(?im)^USER\s+(root|0)(:\S+)?\s*$`.

## Testing

`test_dk_002_detects_root_user`: `USER 0:0` / `USER root:root` now detected; `USER 1000` / `USER 1000:1000` still not.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL