### PR TITLE
fix(rules): DEP-002 detects gitlab:/bitbucket:/gist: git shorthands (#236)

### DIFF
--- a/src/rules/builtin/dependency.rs
+++ b/src/rules/builtin/dependency.rs
@@ -58,9 +58,12 @@ fn dep_002() -> Rule {
         category: Category::SupplyChain,
         confidence: Confidence::Certain,
         patterns: vec![
-            // npm: git://, git+https://, git+ssh://, github:
-            Regex::new(r#":\s*"(git://|git\+https://|git\+ssh://|github:)[^"]*"#)
-                .expect("DEP-002: invalid regex"),
+            // npm: git://, git+https://, git+ssh://, and host shorthands
+            // github:/gitlab:/bitbucket:/gist: (all resolve to remote git). (#236)
+            Regex::new(
+                r#":\s*"(git://|git\+https://|git\+ssh://|(github|gitlab|bitbucket|gist):)[^"]*"#,
+            )
+            .expect("DEP-002: invalid regex"),
             // Cargo: git = "..."
             Regex::new(r#"\bgit\s*=\s*"https?://[^"]*""#).expect("DEP-002: invalid regex"),
             // pip: git+ in requirements
@@ -321,12 +324,22 @@ mod tests {
             r#": "git+https://github.com/user/repo""#,
             r#": "github:user/repo""#,
             r#"git = "https://github.com/user/repo""#,
+            // Regression (#236): other host shorthands.
+            r#": "gitlab:evil/repo""#,
+            r#": "bitbucket:user/repo""#,
+            r#": "gist:a1b2c3d4""#,
         ];
 
         for url in git_urls {
             let matched = dep_002.patterns.iter().any(|p| p.is_match(url));
             assert!(matched, "Should detect git URL: {}", url);
         }
+
+        // A normal semver dependency must not be flagged as a git shorthand.
+        assert!(
+            !dep_002.patterns[0].is_match(r#": "^1.2.3""#),
+            "semver range should not match the git-shorthand pattern"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

DEP-002 (unpinned remote-git dependency) recognized only the `github:` npm shorthand. npm also resolves `gitlab:user/repo`, `bitbucket:user/repo`, and `gist:id` to remote git installs — the same risk class — so those slipped through.

## Fix

Extend the alternation: `(github|gitlab|bitbucket|gist):`.

## Testing

`test_dep_002_detects_git_url`: `gitlab:evil/repo`, `bitbucket:user/repo`, `gist:a1b2c3d4` now detected; a normal semver range `"^1.2.3"` is asserted not to match the git-shorthand pattern.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL