### PR TITLE
fix(rules): anchor SC-005/OP-005 exclusions to whole words, drop `spec` (#232)

### DIFF
--- a/src/rules/builtin/permission.rs
+++ b/src/rules/builtin/permission.rs
@@ -152,7 +152,9 @@ fn op_005() -> Rule {
                 .expect("OP-005: invalid regex"),
             Regex::new(r"chmod\s+[0-7]*7[0-7]*\s").expect("OP-005: invalid regex"), // world-writable
         ],
-        exclusions: vec![Regex::new(r"test|mock|example").expect("OP-005: invalid regex")],
+        // Whole-word only: as a substring, `test` collided with ordinary words
+        // like `latest`, blinding this Critical rule (`sudo … latest-tools`). (#232)
+        exclusions: vec![Regex::new(r"\b(?:test|mock|example)\b").expect("OP-005: invalid regex")],
         message: "Elevated privilege request detected. May allow system-wide changes.",
         recommendation: "Avoid using sudo or elevated privileges in automated tools.",
         fix_hint: Some("Remove sudo/admin privileges and run with minimal permissions"),
@@ -323,6 +325,24 @@ mod tests {
         for (input, should_match) in test_cases {
             let matched = rule.patterns.iter().any(|p| p.is_match(input));
             assert_eq!(matched, should_match, "Failed for input: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_op_005_exclusion_not_bypassed_by_latest() {
+        let rule = op_005();
+        let cases = vec![
+            // Regression (#232): `test` inside `latest` must not suppress OP-005.
+            ("sudo apt-get install latest-tools", true),
+            ("sudo rm -rf /var/cache", true),
+            // Whole-word test/mock/example still exclude.
+            ("sudo test-runner --dry-run", false),
+            ("mock sudo call in example", false),
+        ];
+        for (input, should_match) in cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            assert_eq!(matched && !excluded, should_match, "OP-005: {}", input);
         }
     }
 

--- a/src/rules/builtin/supplychain.rs
+++ b/src/rules/builtin/supplychain.rs
@@ -229,7 +229,10 @@ fn sc_005() -> Rule {
             Regex::new(r#"set(Timeout|Interval)\s*\(\s*["']"#).expect("SC-005: invalid regex"),
         ],
         exclusions: vec![
-            Regex::new(r"test|mock|example|spec").expect("SC-005: invalid regex"),
+            // Whole-word only, and drop `spec`: as a substring it collided with
+            // ordinary code (`config.spec`, `latest`) and blinded this Critical
+            // rule. See #232.
+            Regex::new(r"\b(?:test|mock|example)\b").expect("SC-005: invalid regex"),
             // JSON.parse is safe
             Regex::new(r"JSON\.parse").expect("SC-005: invalid regex"),
         ],
@@ -576,5 +579,25 @@ mod tests {
         let content = include_str!("../../../tests/fixtures/rules/sc_009.txt");
         let findings = crate::rules::snapshot_test::scan_with_rule(&rule, content);
         crate::assert_rule_snapshot!("sc_009", findings);
+    }
+
+    #[test]
+    fn test_sc_005_exclusion_not_bypassed_by_code_tokens() {
+        let rule = sc_005();
+        let cases = vec![
+            // Regression (#232): `spec`/`test` as substrings of code tokens must
+            // NOT suppress dynamic-eval detection.
+            ("eval(config.spec)", true),
+            ("data = eval(atob(p)) // latest", true),
+            ("exec(payload) # respects order", true),
+            // Whole-word test/mock/example still exclude (test fixtures).
+            ("eval(x) // test helper", false),
+            ("mock.eval(payload)", false),
+        ];
+        for (input, should_match) in cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            assert_eq!(matched && !excluded, should_match, "SC-005: {}", input);
+        }
     }
 }


### PR DESCRIPTION
## Summary

Two Critical rules were silently disabled by unanchored substring exclusions applied against the whole line:

- **SC-005** (dynamic eval) excluded `test|mock|example|spec`. `spec` matched `config.spec`; `test` matched `latest`. `eval(config.spec)` was suppressed.
- **OP-005** (sudo/admin) excluded `test|mock|example`; `test` inside `latest` suppressed `sudo … latest-tools`.

## Fix

- SC-005: drop `spec` (a code token, not a documentation marker — and `\bspec\b` would still match `.spec`, so anchoring alone is insufficient) and anchor the rest: `\b(?:test|mock|example)\b`.
- OP-005: anchor to `\b(?:test|mock|example)\b`.

Whole-word `test`/`mock`/`example` still exclude genuine test fixtures.

## Testing

New `test_sc_005_exclusion_not_bypassed_by_code_tokens` and `test_op_005_exclusion_not_bypassed_by_latest`: `eval(config.spec)`, `eval(...) // latest`, `sudo … latest-tools` now detected; `eval(x) // test helper`, `mock.eval(...)`, `sudo test-runner` still excluded.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL