### PR TITLE
fix(rules): drop Bash(...) exclusion masking co-located unrestricted grants (#233)

### DIFF
--- a/src/rules/builtin/permission.rs
+++ b/src/rules/builtin/permission.rs
@@ -116,8 +116,10 @@ fn op_004() -> Rule {
                 .expect("OP-004: invalid regex"),
         ],
         exclusions: vec![
-            // Restricted Bash is OK
-            Regex::new(r"Bash\([^)]+\)").expect("OP-004: invalid regex"),
+            // NOTE: no `Bash(...)` exclusion — the patterns match only a bare
+            // `Bash` (`Bash[^(]` / `Bash = *`), so a line-wide `Bash(...)`
+            // exclusion would mask an unrestricted `Bash` sitting next to a
+            // restricted `Bash(npm:*)`. See #233.
             // Schema/type definitions
             Regex::new(r"(?i)schema|interface|type\s+\w+|typedef").expect("OP-004: invalid regex"),
             // Comments
@@ -216,8 +218,10 @@ fn op_007() -> Rule {
         ],
         exclusions: vec![
             Regex::new(r"^\s*#").expect("OP-007: invalid regex"),
-            Regex::new(r"Bash\([^)]+\)").expect("OP-007: invalid regex"), // Restricted Bash is OK
-            Regex::new(r"Write\([^)]+\)").expect("OP-007: invalid regex"), // Restricted Write is OK
+            // NOTE: no `Bash(...)`/`Write(...)` exclusions — the patterns match
+            // only bare `Bash[^(]` / `Write[^(]`, so line-wide restricted-form
+            // exclusions would mask an unrestricted grant co-located with a
+            // restricted one. See #233.
         ],
         message: "Excessive permission delegation to subagent detected. Subagents should have minimal required permissions.",
         recommendation: "Restrict subagent permissions to only required tools with specific patterns.",
@@ -343,6 +347,41 @@ mod tests {
             let matched = rule.patterns.iter().any(|p| p.is_match(input));
             let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
             assert_eq!(matched && !excluded, should_match, "OP-005: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_op_004_restricted_bash_does_not_mask_unrestricted() {
+        let rule = op_004();
+        let cases = vec![
+            ("allowed-tools: Bash, Read", true),
+            // Regression (#233): co-located restricted Bash must not mask bare Bash.
+            ("allowed-tools: Bash, Bash(npm:*)", true),
+            // Restricted only → not flagged.
+            ("allowed-tools: Bash(npm:*), Read", false),
+        ];
+        for (input, should_match) in cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            assert_eq!(matched && !excluded, should_match, "OP-004: {}", input);
+        }
+    }
+
+    #[test]
+    fn test_op_007_restricted_grant_does_not_mask_unrestricted() {
+        let rule = op_007();
+        let cases = vec![
+            // Regression (#233): bare Bash/Write next to a restricted form.
+            ("subagent allowed-tools: Bash, Bash(git:*)", true),
+            ("subagent allowed-tools: Write, Write(docs/*)", true),
+            // Restricted only → not flagged.
+            ("subagent allowed-tools: Bash(git:*)", false),
+            ("subagent allowed-tools: Read, Grep", false),
+        ];
+        for (input, should_match) in cases {
+            let matched = rule.patterns.iter().any(|p| p.is_match(input));
+            let excluded = rule.exclusions.iter().any(|e| e.is_match(input));
+            assert_eq!(matched && !excluded, should_match, "OP-007: {}", input);
         }
     }
 

--- a/src/rules/builtin/subagent_rules.rs
+++ b/src/rules/builtin/subagent_rules.rs
@@ -86,8 +86,10 @@ fn sa_003() -> Rule {
             Regex::new(r#""tools"\s*:\s*\[[^\]]*"Bash"[^\]]*\]"#).expect("SA-003: invalid regex"),
         ],
         exclusions: vec![
-            // Restricted Bash is OK - Bash(pattern:*)
-            Regex::new(r"Bash\s*\([^)]+\)").expect("SA-003: invalid regex"),
+            // NOTE: no `Bash(...)` exclusion — the patterns above already match
+            // only a *bare* Bash (`Bash,`/`Bash]`/`"Bash"`), never `Bash(...)`.
+            // A line-wide `Bash(...)` exclusion would wrongly mask an unrestricted
+            // `Bash` co-located with a restricted `Bash(git:*)`. See #233.
             // Comments
             Regex::new(r"^\s*#").expect("SA-003: invalid regex"),
         ],
@@ -241,8 +243,12 @@ mod tests {
             ("tools: [Read, Bash]", true),
             ("tools: Bash", true),
             (r#""tools": ["Bash", "Read"]"#, true),
-            // Restricted Bash should NOT match the patterns (exclusions handle this)
+            // Restricted Bash alone should NOT match the patterns.
             ("tools: [Bash(npm:*), Read]", false),
+            // Regression (#233): a co-located restricted Bash must NOT mask the
+            // unrestricted one on the same line.
+            ("tools: [Read, Bash, Bash(git:*)]", true),
+            (r#""tools": ["Bash", "Bash(git:*)"]"#, true),
         ];
 
         for (input, should_match) in test_cases {


### PR DESCRIPTION
## Summary

SA-003, OP-004, and OP-007 excluded a whole line whenever it contained a restricted `Bash(...)` (OP-007 also `Write(...)`). Tool lists are one logical line, so appending a single narrow `Bash(git:*)` neutralized the rule while a co-located **unrestricted** `Bash` went undetected — e.g. `tools: [Read, Bash, Bash(git:*)]` (SA-003 is Critical, arbitrary command execution).

## Fix

The detection patterns already match only a **bare** Bash/Write (`Bash[^(]`, `Bash,`/`Bash]`, `"Bash"`) and never `Bash(...)`, so a restricted-only line was never a finding to begin with. The line-wide `Bash(...)`/`Write(...)` exclusions were both unnecessary and harmful — removed from all three rules. Other exclusions (comments, schema, docs/test context) are unchanged.

## Testing

- `test_sa_003_detects_unrestricted_bash`: `tools: [Read, Bash, Bash(git:*)]` and `["Bash", "Bash(git:*)"]` now detected; restricted-only `[Bash(npm:*), Read]` still clean.
- New `test_op_004_restricted_bash_does_not_mask_unrestricted` and `test_op_007_restricted_grant_does_not_mask_unrestricted`.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL