### PR TITLE
fix(discovery): match file extensions case-insensitively (#228)

### DIFF
--- a/src/discovery/patterns.rs
+++ b/src/discovery/patterns.rs
@@ -23,10 +23,10 @@ impl FilePattern {
             return true;
         }
 
-        // Check extensions
+        // Check extensions (case-insensitively, so `.MD` matches `md`). See #228.
         if !self.extensions.is_empty() {
             if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-                return self.extensions.contains(&ext);
+                return self.extensions.contains(&ext.to_lowercase().as_str());
             }
             return false;
         }

--- a/src/discovery/targets.rs
+++ b/src/discovery/targets.rs
@@ -55,7 +55,7 @@ impl TargetKind {
         if (path_str.contains(".claude/commands/")
             || path_str.contains("/commands/")
             || path_str.starts_with("commands/"))
-            && file_name.ends_with(".md")
+            && file_name.to_lowercase().ends_with(".md")
         {
             return Self::Command;
         }
@@ -72,9 +72,9 @@ impl TargetKind {
             return Self::RulesDir;
         }
 
-        // Check by extension
+        // Check by extension (case-insensitively — `.MD`/`.YAML`). See #228.
         if let Some(ext) = path.extension().and_then(|e| e.to_str()) {
-            match ext {
+            match ext.to_lowercase().as_str() {
                 "md" => {
                     if path_str.contains("scripts/") || path_str.contains(".claude/") {
                         return Self::Skill;

--- a/src/discovery/walker.rs
+++ b/src/discovery/walker.rs
@@ -79,9 +79,14 @@ impl DirectoryWalker {
             return true;
         }
 
+        // Case-insensitive so `.MD`/`.SH` aren't skipped on case-sensitive FS. (#228)
         path.extension()
             .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| self.config.file_extensions.contains(&ext))
+            .is_some_and(|ext| {
+                self.config
+                    .file_extensions
+                    .contains(&ext.to_lowercase().as_str())
+            })
     }
 
     /// Walk the directory and yield matching file paths.

--- a/src/engine/scanners/walker.rs
+++ b/src/engine/scanners/walker.rs
@@ -79,9 +79,15 @@ impl DirectoryWalker {
             return true;
         }
 
+        // Compare case-insensitively so `.MD`/`.SH` on a case-sensitive
+        // filesystem aren't silently skipped (matches SkillFileFilter). See #228.
         path.extension()
             .and_then(|ext| ext.to_str())
-            .is_some_and(|ext| self.config.file_extensions.contains(&ext))
+            .is_some_and(|ext| {
+                self.config
+                    .file_extensions
+                    .contains(&ext.to_lowercase().as_str())
+            })
     }
 
     /// Walk the directory and yield matching file paths.
@@ -184,6 +190,23 @@ mod tests {
         let files: Vec<_> = walker.walk(dir.path()).collect();
 
         assert_eq!(files.len(), 2);
+    }
+
+    #[test]
+    fn test_walk_matches_uppercase_extension() {
+        // Regression (#228): `.MD` must match the `md` filter on a
+        // case-sensitive filesystem.
+        let dir = TempDir::new().unwrap();
+        let commands = dir.path().join(".claude").join("commands");
+        fs::create_dir_all(&commands).unwrap();
+        fs::write(commands.join("evil.MD"), "content").unwrap();
+
+        let config = WalkConfig::new([".claude/commands"]).with_extensions(&["md"]);
+        let walker = DirectoryWalker::new(config);
+        let files: Vec<_> = walker.walk(dir.path()).collect();
+
+        assert_eq!(files.len(), 1, "evil.MD should match the `md` extension");
+        assert!(files[0].ends_with("evil.MD"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`matches_extension` (both the engine walker and the discovery walker), `FilePattern::matches`, and `TargetKind::from_path` compared the raw extension against lowercase extension lists. On a case-sensitive filesystem (Linux/CI), an artifact like `.claude/commands/evil.MD` was filtered out and never scanned. `SkillFileFilter` already lowercases, so the filters were inconsistent.

## Fix

Lowercase the extension before comparison in all four places.

## Testing

New `test_walk_matches_uppercase_extension`: `evil.MD` now matches the `md` filter.

`cargo test --all-features` all green (0 failed); clippy `-D warnings` and `cargo fmt --check` clean.

Fixes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6ZBrM7KdtAvsKxoVn2imL